### PR TITLE
ネストされたタブが削除された時の挙動の修正

### DIFF
--- a/src/model/GroupedTabs.ts
+++ b/src/model/GroupedTabs.ts
@@ -19,6 +19,8 @@ export class GroupedTabs {
 
   get length(): number { return this._values.length }
 
+  get isEmpty(): boolean { return this.length === 0 }
+
   add(tab: Tab): GroupedTabs {
     return new GroupedTabs(this._id, this._name, this._color, [...this._values, tab])
   }

--- a/src/model/PinnedTabs.ts
+++ b/src/model/PinnedTabs.ts
@@ -10,6 +10,8 @@ export class PinnedTabs {
 
   get length(): number { return this._values.length }
 
+  get isEmpty(): boolean { return this.length === 0 }
+
   add(tab: Tab): PinnedTabs {
     return new PinnedTabs([...this._values, tab])
   }

--- a/src/model/Tabs.ts
+++ b/src/model/Tabs.ts
@@ -80,7 +80,7 @@ export class Tabs {
         return true
       })
     }
-    return new Tabs(tabs)
+    return new Tabs(this.removeEmtpyNestedTab(tabs))
   }
 
   private findNormalTabBy(tabId: TabId): Tab | null {
@@ -100,5 +100,13 @@ export class Tabs {
   private findPinnedTabs(): PinnedTabs | null {
     const pinnedTabs = this._values.find((value) => value instanceof PinnedTabs) as (PinnedTabs | undefined)
     return pinnedTabs === undefined ? null : pinnedTabs
+  }
+
+  private removeEmtpyNestedTab(tabs: Tabable[]): Tabable[] {
+    return tabs.filter((value) => {
+        if (value instanceof GroupedTabs && value.isEmpty) return false;
+        if (value instanceof PinnedTabs && value.isEmpty) return false;
+        return true
+    })
   }
 }

--- a/src/view/App.tsx
+++ b/src/view/App.tsx
@@ -58,7 +58,7 @@ export default function App() {
   return (
     <div>
       <CssBaseline />
-      <Box sx={{ width: 400, height: 400 }} >
+      <Box sx={{ width: 400 }} >
         <Header />
         <WindowTabs
           currentWindow={windowsState.currentWindow}


### PR DESCRIPTION
## 概要
* ネストされたタブ、例えばPinnedTabsの中のタブが削除された時、PinnedTabs自体もTabsから削除されるように修正