### PR TITLE
スクロールバーの修正

### DIFF
--- a/dist/popup.html
+++ b/dist/popup.html
@@ -3,6 +3,20 @@
 <head>
   <meta charset="utf-8">
   <title>TabTabTab</title>
+  <style>
+::-webkit-scrollbar {
+  width: 4px;
+}
+::-webkit-scrollbar-track {
+  background: transparent
+}
+::-webkit-scrollbar-thumb {
+  background: #818181;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #C2C2C2;
+}
+  </style>
 </head>
 
 <body>


### PR DESCRIPTION
## 現状
* こんな感じ
![スクリーンショット 2022-02-11 0 29 06](https://user-images.githubusercontent.com/44517313/153440383-b222324c-17bd-40f8-af78-a2fbeaa09187.png)


* 問題点
  * スクロールバーがなくても右に余白ができてしまう
![スクリーンショット 2022-02-11 0 29 16](https://user-images.githubusercontent.com/44517313/153440357-f431f663-7854-4f23-9a11-7652a081b4de.png)

* 理想系
  * スクロールする必要がないときはスクロールバーを表示しない
  * AppBarとWindowTabの箇所は`position: sticky`で固定する
  * 下側のタブ表示部分だけスクロールできるようにする
  * スクロールバーは全体ではなく、タブ表示部分だけにする