### PR TITLE
Make the font size of the group name smaller

### DIFF
--- a/src/view/features/popup/components/GroupedTabList.tsx
+++ b/src/view/features/popup/components/GroupedTabList.tsx
@@ -39,7 +39,7 @@ const GroupedTabList = (props: GroupedTabListProps) => {
   } else {
     groupedTabLabel = (
       <Typography
-        variant="h6"
+        variant="subtitle1"
         component="h6"
         sx={{ px: 1.25, py: 0.25 }}
         style={{

--- a/src/view/features/popup/components/PinnedTabList.tsx
+++ b/src/view/features/popup/components/PinnedTabList.tsx
@@ -51,7 +51,7 @@ const PinnedTabList = (props: PinnedTabListProps) => {
             <Stack direction="row" spacing={1} alignItems="center">
               <ListItemText
                 primary={
-                  <Typography variant="h6" component="h6">
+                  <Typography variant="subtitle1" component="h6">
                     {t.pinned}
                   </Typography>
                 }


### PR DESCRIPTION
* To display many tabs in one area.