### PR TITLE
Fix Unstable Behavior When Sorting TabGroups

### DIFF
--- a/src/view/components/ActionMenu.tsx
+++ b/src/view/components/ActionMenu.tsx
@@ -227,7 +227,7 @@ export const WindowActionMenu = (props: WindowActionMenuProps) => {
       icon: <InputIcon fontSize="small" />,
       action: () => mergeWindow(window.id, windows[currentIndex - 1]),
     },
-    {
+    windows.length > 1 && {
       type: "Divider",
     },
     {

--- a/src/view/components/DragAndDropContext.tsx
+++ b/src/view/components/DragAndDropContext.tsx
@@ -527,7 +527,7 @@ const DragAndDropContext = (props: DragAndDropContextProps) => {
       onDragEnd={onDragEnd}
       measuring={{
         droppable: {
-          strategy: MeasuringStrategy.WhileDragging,
+          strategy: MeasuringStrategy.Always,
         },
       }}
     >

--- a/src/view/components/DragAndDropContext.tsx
+++ b/src/view/components/DragAndDropContext.tsx
@@ -13,6 +13,7 @@ import {
   MouseSensor,
   Over,
   TouchSensor,
+  closestCenter,
   pointerWithin,
   useSensor,
   useSensors,
@@ -20,7 +21,7 @@ import {
 import { RectMap } from "@dnd-kit/core/dist/store/types";
 import { Coordinates } from "@dnd-kit/core/dist/types";
 import { SortableData } from "@dnd-kit/sortable";
-import { useCallback, useContext, useMemo, useState } from "react";
+import { useCallback, useContext, useMemo, useRef, useState } from "react";
 
 import { Tab } from "../../model/Tab";
 import {
@@ -52,7 +53,6 @@ import { useMoveTabToOtherWindow } from "../hooks/useMoveTabToOtherWindow";
 import { useMoveTabOutOfGroup } from "../hooks/useTabOutOfTabGroup";
 import { useUnpinTab } from "../hooks/useUnpinTab";
 
-import SortableTabs from "./SortableTabs";
 import TabGroupContainer from "./TabGroupContainer";
 import TabItem from "./TabItem";
 
@@ -418,6 +418,7 @@ const DragAndDropContext = (props: DragAndDropContextProps) => {
     resetState();
   };
 
+  const lastPointerPosition = useRef<Coordinates>(null);
   const collisionDetectionStrategy: CollisionDetection = useCallback(
     (args: {
       active: Active & { data: { current: { windowId?: number } } };
@@ -426,12 +427,52 @@ const DragAndDropContext = (props: DragAndDropContextProps) => {
       droppableContainers: DroppableContainer[];
       pointerCoordinates: Coordinates | null;
     }) => {
-      const { active } = args;
+      const { active, droppableContainers, pointerCoordinates } = args;
       const window = findWindow(windows, active.data.current?.windowId);
+
+      const draggedItem = findWindowChild(
+        windows,
+        isPinnedId(active.id) ? active.id : Number(active.id),
+      );
+
+      // NOTE: Ensure that if the dragged item is a TabGroup and it is expanded, items within the group are not considered for dropping.
+      if (isTabGroup(draggedItem) && !draggedItem.collapsed) {
+        const isMovingUpwards =
+          pointerCoordinates &&
+          lastPointerPosition.current &&
+          pointerCoordinates.y <= lastPointerPosition.current.y;
+        lastPointerPosition.current = pointerCoordinates;
+
+        const collisionArgs = {
+          ...args,
+          droppableContainers: droppableContainers.filter((container) => {
+            if (
+              container.id === DROPPABLE_EMPTY_WINDOW_COLUMN_ID ||
+              container.id
+                .toString()
+                .startsWith(DROPPABLE_WINDOW_COLUMN_ID_PREFIX)
+            ) {
+              return false;
+            }
+
+            const containerId = isPinnedId(container.id)
+              ? container.id
+              : Number(container.id);
+            const parentContainer = findParentContainer(windows, containerId);
+            return parentContainer && draggedItem.id !== parentContainer.id;
+          }),
+        };
+        // NOTE: Adjust collision detection for downward movements to be more responsive.
+        if (isMovingUpwards) {
+          return pointerWithin(collisionArgs);
+        } else {
+          return closestCenter(collisionArgs);
+        }
+      }
 
       return pointerWithin({
         ...args,
-        droppableContainers: args.droppableContainers.filter((container) => {
+        droppableContainers: droppableContainers.filter((container) => {
           return window && container.id.toString() !== window.id.toString();
         }),
       });
@@ -457,12 +498,9 @@ const DragAndDropContext = (props: DragAndDropContextProps) => {
           }}
         >
           <TabGroupContainer tabGroup={source}>
-            <SortableTabs
-              id={source.id.toString()}
-              parentType="tabGroup"
-              windowId={activeItem.data.current?.windowId}
-              tabs={source.children}
-            />
+            {source.children.map((tab) => (
+              <TabItem key={tab.id} tab={tab} />
+            ))}
           </TabGroupContainer>
         </div>
       );
@@ -491,7 +529,7 @@ const DragAndDropContext = (props: DragAndDropContextProps) => {
       onDragEnd={onDragEnd}
       measuring={{
         droppable: {
-          strategy: MeasuringStrategy.Always,
+          strategy: MeasuringStrategy.WhileDragging,
         },
       }}
     >

--- a/src/view/components/DragAndDropContext.tsx
+++ b/src/view/components/DragAndDropContext.tsx
@@ -217,10 +217,14 @@ const DragAndDropContext = (props: DragAndDropContextProps) => {
     };
 
     if (over.data.current?.type === "window") {
-      if (active.data.current?.type === "tabGroup") {
+      const isSameWindow = active.data.current?.windowId === over.id;
+      if (isSameWindow) {
+        setWindows(windowsBeforeDrag);
+      }
+      if (!isSameWindow && active.data.current?.type === "tabGroup") {
         moveTabGroupToOtherWindow(Number(active.id), Number(over.id));
       }
-      if (active.data.current?.type === "tab") {
+      if (!isSameWindow && active.data.current?.type === "tab") {
         moveTabToOtherWindow(Number(active.id), Number(over.id));
       }
 
@@ -428,7 +432,6 @@ const DragAndDropContext = (props: DragAndDropContextProps) => {
       pointerCoordinates: Coordinates | null;
     }) => {
       const { active, droppableContainers, pointerCoordinates } = args;
-      const window = findWindow(windows, active.data.current?.windowId);
 
       const draggedItem = findWindowChild(
         windows,
@@ -452,7 +455,7 @@ const DragAndDropContext = (props: DragAndDropContextProps) => {
                 .toString()
                 .startsWith(DROPPABLE_WINDOW_COLUMN_ID_PREFIX)
             ) {
-              return false;
+              return true;
             }
 
             const containerId = isPinnedId(container.id)
@@ -470,12 +473,7 @@ const DragAndDropContext = (props: DragAndDropContextProps) => {
         }
       }
 
-      return pointerWithin({
-        ...args,
-        droppableContainers: droppableContainers.filter((container) => {
-          return window && container.id.toString() !== window.id.toString();
-        }),
-      });
+      return pointerWithin(args);
     },
     [windows],
   );

--- a/src/view/features/popup/components/WindowTab.tsx
+++ b/src/view/features/popup/components/WindowTab.tsx
@@ -13,22 +13,23 @@ type WindowTabProps = {
 
 const WindowTab = (props: WindowTabProps) => {
   const { id, label, tabCount, ...other } = props;
-  const { isOver, setNodeRef } = useDroppable({
+  const { active, isOver, setNodeRef } = useDroppable({
     id,
     data: {
       type: "window",
     },
   });
+  const droppable = active && isOver && active.data.current?.windowId !== id;
 
   return (
     <Tab
       ref={setNodeRef}
       sx={{
-        bgcolor: isOver ? blue[100] : undefined,
-        borderColor: isOver ? "primary.main" : undefined,
-        borderWidth: isOver ? 1 : undefined,
-        borderStyle: isOver ? "solid" : undefined,
-        color: isOver ? grey[700] : undefined,
+        bgcolor: droppable ? blue[100] : undefined,
+        borderColor: droppable ? "primary.main" : undefined,
+        borderWidth: droppable ? 1 : undefined,
+        borderStyle: droppable ? "solid" : undefined,
+        color: droppable ? grey[700] : undefined,
       }}
       style={{
         textTransform: "none",


### PR DESCRIPTION
The issue was caused by elements within a TabGroup being droppable during a drag operation. To address this, I have made changes so that tabs within a target group are not droppable when the TabGroup is being dragged. Additionally, I have refined the collision detection algorithm to facilitate easier sorting while dragging a TabGroup.