### PR TITLE
Fix Issue Where Window Could Not Always Be Closed

### DIFF
--- a/src/view/components/ActionMenu.tsx
+++ b/src/view/components/ActionMenu.tsx
@@ -258,7 +258,7 @@ export const WindowActionMenu = (props: WindowActionMenuProps) => {
       type: "MenuItem",
       label: t.closeWindow,
       icon: <CancelPresentationIcon fontSize="small" />,
-      action: () => closeWindow(window.id),
+      action: () => closeWindow(window),
     },
   ];
 

--- a/src/view/features/options/hooks/useCloseWindow.ts
+++ b/src/view/features/options/hooks/useCloseWindow.ts
@@ -1,18 +1,15 @@
 import { useCallback, useContext } from "react";
 
-import {
-  closeWindow,
-  getWindows,
-} from "../../../../repository/WindowsRepository";
+import { Window } from "../../../../model/Window";
+import { closeWindow } from "../../../../repository/WindowsRepository";
 import { WindowsContext } from "../../../contexts/WindowsContext";
 
-export const useCloseWindow = (): ((id: number) => Promise<void>) => {
+export const useCloseWindow = (): ((window: Window) => Promise<void>) => {
   const { setWindows } = useContext(WindowsContext);
 
   const callback = useCallback(
-    async (id: number) => {
-      await closeWindow(id);
-      const newWindows = await getWindows();
+    async (window: Window) => {
+      const newWindows = await closeWindow(window);
       setWindows(newWindows);
     },
     [setWindows],


### PR DESCRIPTION
Resolved an issue where windows were not closing immediately when using `chrome.windows.remove`, likely due to high operation load. Switched to `chrome.tabs.remove(tabIds)` for closing tabs individually within the window, ensuring reliable and immediate closure.
