### PR TITLE
Fixed an issue where 'Resolve Duplicates' text appears outside of duplicate chip hover

### DIFF
--- a/src/view/components/TabItem.tsx
+++ b/src/view/components/TabItem.tsx
@@ -105,6 +105,7 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
     event.stopPropagation();
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     resolveDuplicateTabs(tab);
+    setIsDuplicatedChipHovered(false);
   };
 
   return (


### PR DESCRIPTION
Resolved an issue where 'Resolve Duplicates' text incorrectly appears due to `isDuplicatedChipHovered` state remaining `true` after duplicates are resolved