### PR TITLE
Fix issue where re-pressing active button in ToggleButtonGroup hides page

### DIFF
--- a/src/view/components/RestorePage/index.tsx
+++ b/src/view/components/RestorePage/index.tsx
@@ -30,6 +30,11 @@ const RestorePage = (props: RestorePageProps) => {
     },
   ];
 
+  const onChangePage = (_: React.MouseEvent<HTMLElement>, page: Page) => {
+    if (page === null) return;
+    setCurrentPage(page);
+  };
+
   return (
     <Stack sx={{ height: "100%" }} spacing={dense ? 1 : 2}>
       <ToggleButtonGroup
@@ -37,7 +42,7 @@ const RestorePage = (props: RestorePageProps) => {
         exclusive
         value={currentPage}
         color="primary"
-        onChange={(_, value: Page) => setCurrentPage(value)}
+        onChange={onChangePage}
       >
         {pages.map((page) => (
           <ToggleButton value={page.value} style={{ textTransform: "none" }}>


### PR DESCRIPTION
Fixed an issue in `ToggleButtonGroup` where pressing an active button again would set its value to `null`, causing the page to be hidden. The solution implemented ensures the page state remains unchanged when `null` is encountered.