### PR TITLE
Add missing keys to Japanese locale

### DIFF
--- a/dist/_locales/ja/messages.json
+++ b/dist/_locales/ja/messages.json
@@ -23,6 +23,10 @@
     "message": "ウィンドウを追加",
     "description": "Text used to display the action for adding a window"
   },
+  "save_window": {
+    "message": "ウィンドウを保存",
+    "description": "Text used to display the action for save a window"
+  },
   "merge_right_window": {
     "message": "右にマージ",
     "description": "Text used to display the action for merge a right window"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "@vitejs/plugin-react": "^4.2.1",
-        "chromex-locale-lint": "^0.0.3",
+        "chromex-locale-lint": "^0.1.0",
         "eslint": "^8.56.0",
         "eslint-plugin-autofix": "^1.1.0",
         "eslint-plugin-import": "^2.29.1",
@@ -2495,9 +2495,9 @@
       }
     },
     "node_modules/chromex-locale-lint": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/chromex-locale-lint/-/chromex-locale-lint-0.0.3.tgz",
-      "integrity": "sha512-gZeKz+KSYeen1Hr0BXlmGJICLgxBc07PjUgnB6TbZQbTfi5QYNykvLydjmykVf54bIIJxf3u2RgCA/eshB2F2Q==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chromex-locale-lint/-/chromex-locale-lint-0.1.0.tgz",
+      "integrity": "sha512-39cCoBfFqt7puJZrjbwF1NKTffbzWY/1ftfa1ysv+PEXeHoPyvDIXCszmTs7yDYcBOtP7vt9n5YVGq5PAHxDtw==",
       "dev": true,
       "dependencies": {
         "chalk": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint --fix './src/**/*.{js,ts,jsx,tsx}' './test/**/*.{js,ts,jsx,tsx}'",
     "format": "prettier './src/**/*.{js,ts,jsx,tsx}' './test/**/*.{js,ts,jsx,tsx}' --check",
     "format:fix": "prettier './src/**/*.{js,ts,jsx,tsx}' './test/**/*.{js,ts,jsx,tsx}' --write",
-    "locale-lint": "chromex-locale-lint --localesDir dist/_locales"
+    "locale-lint": "chromex-locale-lint --localesDir dist/_locales --strict"
   },
   "author": "okaryo",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "@vitejs/plugin-react": "^4.2.1",
-    "chromex-locale-lint": "^0.0.3",
+    "chromex-locale-lint": "^0.1.0",
     "eslint": "^8.56.0",
     "eslint-plugin-autofix": "^1.1.0",
     "eslint-plugin-import": "^2.29.1",


### PR DESCRIPTION
As the title suggests, I found some missing keys in the Japanese locale files and have added them. To ensure such issues are caught at the CI stage, I've updated `chromex-locale-lint` to version `0.1.0` and enabled the `--strict` flag.