### PR TITLE
Reflect changes to windows and tabs in real-time on popup and options page

### DIFF
--- a/src/repository/TabsRepository.ts
+++ b/src/repository/TabsRepository.ts
@@ -215,3 +215,18 @@ const deserializeToTab = (serializedTab: SerializedTab): Tab => {
       : null,
   };
 };
+
+export const addListenerOnUpdateTabs = (callback: () => Promise<void>) => {
+  const listener = async () => {
+    await callback();
+  };
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  chrome.tabs.onUpdated.addListener(listener);
+
+  return listener;
+};
+
+export const removeListenerOnUpdateTabs = (listener: () => Promise<void>) => {
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  chrome.tabs.onUpdated.removeListener(listener);
+};

--- a/src/view/hooks/useWindows.ts
+++ b/src/view/hooks/useWindows.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { Window } from "../../model/Window";
+import {
+  addListenerOnUpdateTabs,
+  removeListenerOnUpdateTabs,
+} from "../../repository/TabsRepository";
 import { getWindows } from "../../repository/WindowsRepository";
 
 export const useWindows = () => {
@@ -11,20 +15,26 @@ export const useWindows = () => {
       (a, b) => (b.focused ? 1 : 0) - (a.focused ? 1 : 0),
     );
   };
-
-  useEffect(() => {
-    const initState = async () => {
-      const windows = await getWindows();
-      setState(sortByFocused(windows));
-    };
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    initState();
-  }, []);
-
   const setWindows = useCallback((windows: Window[]) => {
     const sortedWindows = sortByFocused(windows);
     setState(sortedWindows);
   }, []);
+
+  useEffect(() => {
+    const initState = async () => {
+      const windows = await getWindows();
+      setWindows(windows);
+    };
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    initState();
+
+    const listenerOnUpdateTabs = addListenerOnUpdateTabs(async () => {
+      const windows = await getWindows();
+      setWindows(windows);
+    });
+
+    return () => removeListenerOnUpdateTabs(listenerOnUpdateTabs);
+  }, [setWindows]);
 
   return {
     windows,


### PR DESCRIPTION
In the auto-group feature, changes to tabs and groups running in the background are now reflected in the popup and options.

#308 #268