### PR TITLE
Preserve Tab Last Active Time Across Browser Restarts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,14 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "error",
+        "useHookAtTopLevel": "error"
+      },
+      "nursery": {
+        "noUnusedImports": "error"
+      }
     },
     "ignore": ["node_modules/*", "dist/*"]
   },

--- a/src/background/AutoTabGrouping.ts
+++ b/src/background/AutoTabGrouping.ts
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-misused-promises: 0 */
-
 import { parse } from "tldts";
 
 import { TabGroupSetting } from "../model/TabGroupSetting";

--- a/src/background/TabActivityTracker.ts
+++ b/src/background/TabActivityTracker.ts
@@ -1,4 +1,3 @@
-/* eslint @typescript-eslint/no-floating-promises: 0 */
 import { cleanupTabLastAccesses } from "../repository/ChromeStorage";
 import {
   updateRecentActiveTabs,

--- a/src/background/TabActivityTracker.ts
+++ b/src/background/TabActivityTracker.ts
@@ -1,5 +1,5 @@
-import { cleanupTabLastAccesses } from "../repository/ChromeStorage";
 import {
+  cleanupTabLastActivatedAt,
   updateRecentActiveTabs,
   updateTabLastActivatedAt,
 } from "../repository/TabsRepository";
@@ -19,6 +19,6 @@ export const addTabAccessesListener = () => {
     updateRecentActiveTabs(tabId);
   });
   chrome.tabs.onRemoved.addListener((tabId) => {
-    cleanupTabLastAccesses(tabId);
+    cleanupTabLastActivatedAt(tabId);
   });
 };

--- a/src/background/TabActivityTracker.ts
+++ b/src/background/TabActivityTracker.ts
@@ -1,42 +1,25 @@
 /* eslint @typescript-eslint/no-floating-promises: 0 */
+import { cleanupTabLastAccesses } from "../repository/ChromeStorage";
 import {
-  deleteLastActivatedAtOfTab,
-  updateLastActivatedAtOfTab,
   updateRecentActiveTabs,
+  updateTabLastActivatedAt,
 } from "../repository/TabsRepository";
 
-export const addListenerOnTabActivated = () => {
+export const addTabAccessesListener = () => {
+  chrome.tabs.onCreated.addListener((tab) => {
+    updateTabLastActivatedAt(tab.id);
+    updateRecentActiveTabs(tab.id);
+  });
   chrome.tabs.onActivated.addListener((activeInfo) => {
     const { tabId } = activeInfo;
-    updateLastActivatedAtOfTab(tabId);
-    updateRecentActiveTabs(tabId);
-  });
-  chrome.tabs.onAttached.addListener((tabId) => {
-    updateLastActivatedAtOfTab(tabId);
-    updateRecentActiveTabs(tabId);
-  });
-  chrome.tabs.onHighlighted.addListener((highlightInfo) => {
-    const { tabIds } = highlightInfo;
-    for (const tabId of tabIds) {
-      updateLastActivatedAtOfTab(tabId);
-      updateRecentActiveTabs(tabId);
-    }
-  });
-  chrome.tabs.onMoved.addListener((tabId) => {
-    updateLastActivatedAtOfTab(tabId);
+    updateTabLastActivatedAt(tabId);
     updateRecentActiveTabs(tabId);
   });
   chrome.tabs.onUpdated.addListener((tabId) => {
-    updateLastActivatedAtOfTab(tabId);
+    updateTabLastActivatedAt(tabId, { onlyActiveTab: true });
     updateRecentActiveTabs(tabId);
   });
-};
-
-export const addListenerOnTabClosed = () => {
-  chrome.tabs.onDetached.addListener((tabId) => {
-    deleteLastActivatedAtOfTab(tabId);
-  });
   chrome.tabs.onRemoved.addListener((tabId) => {
-    deleteLastActivatedAtOfTab(tabId);
+    cleanupTabLastAccesses(tabId);
   });
 };

--- a/src/background/TabCleanerScheduler.ts
+++ b/src/background/TabCleanerScheduler.ts
@@ -11,7 +11,6 @@ export const activateTabCleanerScheduler = async () => {
     periodInMinutes: 1,
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   chrome.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name !== tabCleanerAlarmName) return;
 

--- a/src/background/TabCleanerScheduler.ts
+++ b/src/background/TabCleanerScheduler.ts
@@ -20,7 +20,8 @@ export const activateTabCleanerScheduler = async () => {
     if (!tabCleanerSetting.enabled) return;
 
     for (const tab of flatTabsInWindows(windows)) {
-      if (shouldCleanUp(tabCleanerSetting, tab, new Date())) {
+      const currentDateTime = new Date();
+      if (shouldCleanUp(tabCleanerSetting, tab, currentDateTime)) {
         await removeTab(tab.id);
       }
     }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,14 +1,11 @@
 /* eslint @typescript-eslint/no-floating-promises: 0 */
+
 import { addTabGroupingListeners } from "./AutoTabGrouping";
-import {
-  addListenerOnTabActivated,
-  addListenerOnTabClosed,
-} from "./TabActivityTracker";
+import { addTabAccessesListener } from "./TabActivityTracker";
 import { activateTabCleanerScheduler } from "./TabCleanerScheduler";
 
 // TabActivityTracker
-addListenerOnTabActivated();
-addListenerOnTabClosed();
+addTabAccessesListener();
 
 // TabCleanerScheduler
 activateTabCleanerScheduler();

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-floating-promises: 0 */
-
 import { addTabGroupingListeners } from "./AutoTabGrouping";
 import { addTabAccessesListener } from "./TabActivityTracker";
 import { activateTabCleanerScheduler } from "./TabCleanerScheduler";

--- a/src/model/Window.ts
+++ b/src/model/Window.ts
@@ -130,39 +130,6 @@ export const indexOfWindowChild = (
   }, 0);
 };
 
-export const updateLastActivatedAtOfTab = (
-  windows: Window[],
-  tabId: number,
-  lastActivatedAt: Date,
-): Window[] => {
-  return windows.map((window) => {
-    window.children = window.children.map((child) => {
-      if (isTabContainer(child)) {
-        return {
-          ...child,
-          children: child.children.map((tab) => {
-            if (tab.id === tabId) {
-              return {
-                ...tab,
-                lastActivatedAt,
-              };
-            }
-            return tab;
-          }),
-        };
-      }
-      if (child.id === tabId) {
-        return {
-          ...child,
-          lastActivatedAt,
-        };
-      }
-      return child;
-    });
-    return window;
-  });
-};
-
 export const findTabsByTitleOrUrl = (
   windows: Window[],
   value: string,

--- a/src/repository/ChromeStorage.ts
+++ b/src/repository/ChromeStorage.ts
@@ -1,203 +1,313 @@
-import { DurationUnit } from "../model/TabCleaner";
+import { PopupSize } from "../model/PopupSize";
+import { DurationUnit, TabCleaner } from "../model/TabCleaner";
 import { TabGroupSetting } from "../model/TabGroupSetting";
 import { generateHash } from "../utility/hash";
 
 export namespace ChromeLocalStorage {
-  export const TAB_CLEANER_SETTING_KEY = "tab_cleaner_setting";
-  export const POPUP_SIZE_SETTING_KEY = "popup_size_setting";
-  export const POPUP_ELEMENT_SCALE_SETTING_KEY = "popup_element_scale";
-  export const THEME_KEY = "theme";
-  export const STORED_WINDOWS_KEY = "stored_windows";
-  export const STORED_TAB_GROUPS_KEY = "stored_tab_groups";
+  const TAB_CLEANER_SETTING_KEY = "tab_cleaner_setting";
+  const POPUP_SIZE_SETTING_KEY = "popup_size_setting";
+  const POPUP_ELEMENT_SCALE_SETTING_KEY = "popup_element_scale";
+  const THEME_KEY = "theme";
+  const STORED_WINDOWS_KEY = "stored_windows";
+  const STORED_TAB_GROUPS_KEY = "stored_tab_groups";
   export const TAB_GROUP_SETTING_KEY = "tab_group_setting";
   export const TAB_LAST_ACCESSES_KEY = "tab_last_accesses_in_local";
+
+  // TabCleanerSetting
+  type TabCleanerSettingStorageObject = {
+    [TAB_CLEANER_SETTING_KEY]: {
+      isEnabled: boolean;
+      duration: number;
+      durationUnit: DurationUnit;
+    };
+  };
+  export const getTabCleanerSetting = async () => {
+    const { [TAB_CLEANER_SETTING_KEY]: setting } =
+      (await chrome.storage.local.get(
+        TAB_CLEANER_SETTING_KEY,
+      )) as TabCleanerSettingStorageObject;
+    return setting;
+  };
+  export const updateTabCleanerSetting = async (setting: TabCleaner) => {
+    return chrome.storage.local.set({
+      [TAB_CLEANER_SETTING_KEY]: {
+        isEnabled: setting.enabled,
+        duration: setting.duration,
+        durationUnit: setting.durationUnit,
+      },
+    });
+  };
+
+  // PopupSizeSetting
+  type PopupSizeSettingStorageObject = {
+    [POPUP_SIZE_SETTING_KEY]: {
+      height: number;
+      width: number;
+    };
+  };
+  export const getPopupSizeSetting = async () => {
+    const { [POPUP_SIZE_SETTING_KEY]: setting } =
+      (await chrome.storage.local.get(
+        POPUP_SIZE_SETTING_KEY,
+      )) as PopupSizeSettingStorageObject;
+    return setting;
+  };
+  export const updatePopupSizeSetting = async (setting: PopupSize) => {
+    return chrome.storage.local.set({
+      [POPUP_SIZE_SETTING_KEY]: {
+        height: setting.height,
+        width: setting.width,
+      },
+    });
+  };
+
+  // PopupElementScaleSetting
+  type PopupElementScaleSettingStorageObject = {
+    [POPUP_ELEMENT_SCALE_SETTING_KEY]: number;
+  };
+  export const getPopupElementScaleSetting = async () => {
+    const { [POPUP_ELEMENT_SCALE_SETTING_KEY]: setting } =
+      (await chrome.storage.local.get(
+        POPUP_ELEMENT_SCALE_SETTING_KEY,
+      )) as PopupElementScaleSettingStorageObject;
+    return setting;
+  };
+  export const updatePopupElementScaleSetting = (scale: number) => {
+    return chrome.storage.local.set({
+      [POPUP_ELEMENT_SCALE_SETTING_KEY]: scale,
+    });
+  };
+
+  // Theme
+  type Theme = "light" | "dark";
+  export type ThemeStorageObject = {
+    [THEME_KEY]: Theme;
+  };
+  export const getTheme = async () => {
+    const { [THEME_KEY]: theme } = (await chrome.storage.local.get(
+      THEME_KEY,
+    )) as ThemeStorageObject;
+    return theme;
+  };
+  export const updateTheme = (theme: Theme) => {
+    return chrome.storage.local.set({
+      [THEME_KEY]: theme,
+    });
+  };
+
+  // StoredWindows and StoredTabGroups
+  type SerializedStoredWindow = {
+    type: "window";
+    internalUid: string;
+    name: string;
+    storedAt: string;
+    children: (SerializedStoredTabContainerInWindow | SerializedStoredTab)[];
+  };
+  type SerializedStoredTabContainerInWindow =
+    | SerializedStoredPinned
+    | Omit<SerializedStoredTabGroup, "storedAt">;
+  type SerializedStoredTabContainerBase = {
+    type: "pinned" | "tabGroup";
+    internalUid: string;
+    children: SerializedStoredTab[];
+  };
+  type SerializedStoredPinned = SerializedStoredTabContainerBase & {
+    type: "pinned";
+  };
+  type SerializedStoredTabGroup = SerializedStoredTabContainerBase & {
+    type: "tabGroup";
+    storedAt: string;
+    name: string;
+    color: string;
+  };
+  export type SerializedStoredTab = {
+    type: "tab";
+    internalUid: string;
+    title: string;
+    url: string;
+    favIconUrl: string | null;
+  };
+  type StoredWindowsObject = {
+    [STORED_WINDOWS_KEY]: SerializedStoredWindow[];
+  };
+  type StoredTabGroupsObject = {
+    [STORED_TAB_GROUPS_KEY]: SerializedStoredTabGroup[];
+  };
+  export const getStoredWindows = async () => {
+    const { [STORED_WINDOWS_KEY]: storedWindows } =
+      (await chrome.storage.local.get(
+        STORED_WINDOWS_KEY,
+      )) as StoredWindowsObject;
+    return storedWindows;
+  };
+  export const updateStoredWindows = async (
+    windows: SerializedStoredWindow[],
+  ) => {
+    return await chrome.storage.local.set({
+      [STORED_WINDOWS_KEY]: windows,
+    });
+  };
+  export const getStoredTabGroups = async () => {
+    const { [STORED_TAB_GROUPS_KEY]: storedTabGroups } =
+      (await chrome.storage.local.get(
+        STORED_TAB_GROUPS_KEY,
+      )) as StoredTabGroupsObject;
+    return storedTabGroups;
+  };
+  export const updateStoredTabGroups = async (
+    groups: SerializedStoredTabGroup[],
+  ) => {
+    return await chrome.storage.local.set({
+      [STORED_TAB_GROUPS_KEY]: groups,
+    });
+  };
+
+  // TabGroupSetting
+  type TabGroupSettingStorageObject = {
+    [TAB_GROUP_SETTING_KEY]: TabGroupSetting;
+  };
+  export const getTabGroupSetting = async () => {
+    const { [TAB_GROUP_SETTING_KEY]: setting } =
+      (await chrome.storage.local.get(
+        TAB_GROUP_SETTING_KEY,
+      )) as TabGroupSettingStorageObject;
+    return setting;
+  };
+  export const updateTabGroupSetting = async (setting: TabGroupSetting) => {
+    return await chrome.storage.local.set({ [TAB_GROUP_SETTING_KEY]: setting });
+  };
 }
 
 export namespace ChromeSessionStorage {
+  const RECENT_ACTIVE_TABS_KEY = "recent_active_tabs";
   export const TAB_LAST_ACCESSES_KEY = "tab_last_accesses_in_session";
-  export const RECENT_ACTIVE_TABS_KEY = "recent_active_tabs";
+
+  // RecentActiveTabs
+  export type SerializedTab = {
+    id: number;
+    groupId: number | null;
+    windowId: number | null;
+    title: string;
+    url: string;
+    favIconUrl: string | null;
+    highlighted: boolean;
+    audible: boolean;
+    pinned: boolean;
+    lastActivatedAt: string | null;
+  };
+  type RecentActiveTabsStorageObject = {
+    [RECENT_ACTIVE_TABS_KEY]: SerializedTab[];
+  };
+  export const getRecentActiveTabs = async () => {
+    const { [RECENT_ACTIVE_TABS_KEY]: recentActiveTabs } =
+      (await chrome.storage.session.get(
+        RECENT_ACTIVE_TABS_KEY,
+      )) as RecentActiveTabsStorageObject;
+    return recentActiveTabs;
+  };
+  export const updateRecentActiveTabs = async (tabs: SerializedTab[]) => {
+    return chrome.storage.session.set({
+      [RECENT_ACTIVE_TABS_KEY]: tabs,
+    });
+  };
 }
 
-export type TabCleanerSettingStorageObject = {
-  [ChromeLocalStorage.TAB_CLEANER_SETTING_KEY]: {
-    isEnabled: boolean;
-    duration: number;
-    durationUnit: DurationUnit;
-  };
-};
-
-export type PopupSizeSettingStorageObject = {
-  [ChromeLocalStorage.POPUP_SIZE_SETTING_KEY]: {
-    height: number;
-    width: number;
-  };
-};
-
-export type PopupElementScaleSettingStorageObject = {
-  [ChromeLocalStorage.POPUP_ELEMENT_SCALE_SETTING_KEY]: number;
-};
-
-type Theme = "light" | "dark";
-export type ThemeStorageObject = {
-  [ChromeLocalStorage.THEME_KEY]: Theme;
-};
-
-type SerializedStoredWindow = {
-  type: "window";
-  internalUid: string;
-  name: string;
-  storedAt: string;
-  children: (SerializedStoredTabContainerInWindow | SerializedStoredTab)[];
-};
-type SerializedStoredTabContainerInWindow =
-  | SerializedStoredPinned
-  | Omit<SerializedStoredTabGroup, "storedAt">;
-type SerializedStoredTabContainerBase = {
-  type: "pinned" | "tabGroup";
-  internalUid: string;
-  children: SerializedStoredTab[];
-};
-type SerializedStoredPinned = SerializedStoredTabContainerBase & {
-  type: "pinned";
-};
-type SerializedStoredTabGroup = SerializedStoredTabContainerBase & {
-  type: "tabGroup";
-  storedAt: string;
-  name: string;
-  color: string;
-};
-export type SerializedStoredTab = {
-  type: "tab";
-  internalUid: string;
-  title: string;
-  url: string;
-  favIconUrl: string | null;
-};
-export type StoredWindowsObject = {
-  [ChromeLocalStorage.STORED_WINDOWS_KEY]: SerializedStoredWindow[];
-};
-export type StoredTabGroupsObject = {
-  [ChromeLocalStorage.STORED_TAB_GROUPS_KEY]: SerializedStoredTabGroup[];
-};
-
-// TabLastAccesses
-type TabLastAccessesLocalStorageObject = {
-  [ChromeLocalStorage.TAB_LAST_ACCESSES_KEY]: {
-    [tabId: string]: {
-      lastActivatedAt: string;
-    };
-  };
-};
-type TabLastAccessesSessionStorageObject = {
-  [ChromeSessionStorage.TAB_LAST_ACCESSES_KEY]: {
-    [tabHashKey: string]: {
-      lastActivatedAt: string;
-    };
-  };
-};
-export const tabKeyForLastAccessesInLocal = async (
-  title: string,
-  url: string,
-) => {
-  return generateHash(`${title}${url}`);
-};
-export const getTabLastAccesses = async () => {
-  const {
-    [ChromeLocalStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInLocal = {},
-  } = (await chrome.storage.local.get(
-    ChromeLocalStorage.TAB_LAST_ACCESSES_KEY,
-  )) as TabLastAccessesLocalStorageObject;
-  const {
-    [ChromeSessionStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInSession = {},
-  } = (await chrome.storage.session.get(
-    ChromeSessionStorage.TAB_LAST_ACCESSES_KEY,
-  )) as TabLastAccessesSessionStorageObject;
-
-  return {
-    local: lastAccessesInLocal,
-    session: lastAccessesInSession,
-  };
-};
-export const updateTabLastAccesses = async (tab: chrome.tabs.Tab) => {
-  const lastActivatedAt = new Date().toISOString();
-
-  const key = await tabKeyForLastAccessesInLocal(
-    tab.title,
-    tab.url !== "" ? tab.url : tab.pendingUrl,
-  );
-  const {
-    [ChromeLocalStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInLocal = {},
-  } = (await chrome.storage.local.get(
-    ChromeLocalStorage.TAB_LAST_ACCESSES_KEY,
-  )) as TabLastAccessesLocalStorageObject;
-  await chrome.storage.local.set({
+export namespace ChromeStorage {
+  // TabLastAccesses
+  type TabLastAccessesLocalStorageObject = {
     [ChromeLocalStorage.TAB_LAST_ACCESSES_KEY]: {
-      ...lastAccessesInLocal,
-      [key]: {
-        lastActivatedAt,
-      },
-    },
-  });
-
-  const {
-    [ChromeSessionStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInSession = {},
-  } = (await chrome.storage.session.get(
-    ChromeSessionStorage.TAB_LAST_ACCESSES_KEY,
-  )) as TabLastAccessesSessionStorageObject;
-  await chrome.storage.session.set({
+      [tabId: string]: {
+        lastActivatedAt: string;
+      };
+    };
+  };
+  type TabLastAccessesSessionStorageObject = {
     [ChromeSessionStorage.TAB_LAST_ACCESSES_KEY]: {
-      ...lastAccessesInSession,
-      [tab.id]: {
-        lastActivatedAt: new Date().toISOString(),
-      },
-    },
-  });
-};
-export const cleanupTabLastAccesses = async (tabId: number) => {
-  const {
-    [ChromeSessionStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInSession = {},
-  } = (await chrome.storage.session.get(
-    ChromeSessionStorage.TAB_LAST_ACCESSES_KEY,
-  )) as TabLastAccessesSessionStorageObject;
-  delete lastAccessesInSession[tabId];
+      [tabHashKey: string]: {
+        lastActivatedAt: string;
+      };
+    };
+  };
+  export const tabKeyForLastAccessesInLocal = (title: string, url: string) =>
+    generateHash(`${title}${url}`);
+  export const getTabLastAccesses = async () => {
+    const {
+      [ChromeLocalStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInLocal = {},
+    } = (await chrome.storage.local.get(
+      ChromeLocalStorage.TAB_LAST_ACCESSES_KEY,
+    )) as TabLastAccessesLocalStorageObject;
+    const {
+      [ChromeSessionStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInSession = {},
+    } = (await chrome.storage.session.get(
+      ChromeSessionStorage.TAB_LAST_ACCESSES_KEY,
+    )) as TabLastAccessesSessionStorageObject;
 
-  const {
-    [ChromeLocalStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInLocal = {},
-  } = (await chrome.storage.local.get(
-    ChromeLocalStorage.TAB_LAST_ACCESSES_KEY,
-  )) as TabLastAccessesLocalStorageObject;
+    return {
+      local: lastAccessesInLocal,
+      session: lastAccessesInSession,
+    };
+  };
+  export const updateTabLastAccesses = async (tab: chrome.tabs.Tab) => {
+    const lastActivatedAt = new Date().toISOString();
 
-  const windows = await chrome.windows.getAll({ populate: true });
-  const cleanedUpInLocal = {};
-  for (const tab of windows.flatMap((window) => window.tabs)) {
     const key = await tabKeyForLastAccessesInLocal(
       tab.title,
       tab.url !== "" ? tab.url : tab.pendingUrl,
     );
-    cleanedUpInLocal[key] = lastAccessesInLocal[key];
-  }
+    const {
+      [ChromeLocalStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInLocal = {},
+    } = (await chrome.storage.local.get(
+      ChromeLocalStorage.TAB_LAST_ACCESSES_KEY,
+    )) as TabLastAccessesLocalStorageObject;
+    await chrome.storage.local.set({
+      [ChromeLocalStorage.TAB_LAST_ACCESSES_KEY]: {
+        ...lastAccessesInLocal,
+        [key]: {
+          lastActivatedAt,
+        },
+      },
+    });
 
-  await chrome.storage.local.set({
-    [ChromeLocalStorage.TAB_LAST_ACCESSES_KEY]: cleanedUpInLocal,
-  });
-};
+    const {
+      [ChromeSessionStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInSession = {},
+    } = (await chrome.storage.session.get(
+      ChromeSessionStorage.TAB_LAST_ACCESSES_KEY,
+    )) as TabLastAccessesSessionStorageObject;
+    await chrome.storage.session.set({
+      [ChromeSessionStorage.TAB_LAST_ACCESSES_KEY]: {
+        ...lastAccessesInSession,
+        [tab.id]: {
+          lastActivatedAt: new Date().toISOString(),
+        },
+      },
+    });
+  };
+  export const cleanupTabLastAccesses = async (tabId: number) => {
+    const {
+      [ChromeSessionStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInSession = {},
+    } = (await chrome.storage.session.get(
+      ChromeSessionStorage.TAB_LAST_ACCESSES_KEY,
+    )) as TabLastAccessesSessionStorageObject;
+    delete lastAccessesInSession[tabId];
 
-export type SerializedTab = {
-  id: number;
-  groupId: number | null;
-  windowId: number | null;
-  title: string;
-  url: string;
-  favIconUrl: string | null;
-  highlighted: boolean;
-  audible: boolean;
-  pinned: boolean;
-  lastActivatedAt: string | null;
-};
-export type RecentActiveTabsStorageObject = {
-  [ChromeSessionStorage.RECENT_ACTIVE_TABS_KEY]: SerializedTab[];
-};
+    const {
+      [ChromeLocalStorage.TAB_LAST_ACCESSES_KEY]: lastAccessesInLocal = {},
+    } = (await chrome.storage.local.get(
+      ChromeLocalStorage.TAB_LAST_ACCESSES_KEY,
+    )) as TabLastAccessesLocalStorageObject;
 
-export type TabGroupSettingStorageObject = {
-  [ChromeLocalStorage.TAB_GROUP_SETTING_KEY]: TabGroupSetting;
-};
+    const windows = await chrome.windows.getAll({ populate: true });
+    const cleanedUpInLocal = {};
+    for (const tab of windows.flatMap((window) => window.tabs)) {
+      const key = await tabKeyForLastAccessesInLocal(
+        tab.title,
+        tab.url !== "" ? tab.url : tab.pendingUrl,
+      );
+      cleanedUpInLocal[key] = lastAccessesInLocal[key];
+    }
+
+    await chrome.storage.local.set({
+      [ChromeLocalStorage.TAB_LAST_ACCESSES_KEY]: cleanedUpInLocal,
+    });
+  };
+}

--- a/src/repository/SettingsRepository.ts
+++ b/src/repository/SettingsRepository.ts
@@ -1,33 +1,20 @@
 import { PopupSize, defaultPopupSize } from "../model/PopupSize";
 
-import {
-  ChromeLocalStorage,
-  PopupElementScaleSettingStorageObject,
-  PopupSizeSettingStorageObject,
-} from "./ChromeStorage";
+import { ChromeLocalStorage } from "./ChromeStorage";
 
 export const getPopupSizeSetting = async (): Promise<PopupSize> => {
-  const { popup_size_setting: setting } = (await chrome.storage.local.get(
-    ChromeLocalStorage.POPUP_SIZE_SETTING_KEY,
-  )) as PopupSizeSettingStorageObject;
+  const setting = await ChromeLocalStorage.getPopupSizeSetting();
   if (!setting) return defaultPopupSize;
 
   return { height: setting.height, width: setting.width };
 };
 
 export const updatePopupSizeSetting = (popupSize: PopupSize): Promise<void> => {
-  return chrome.storage.local.set({
-    [ChromeLocalStorage.POPUP_SIZE_SETTING_KEY]: {
-      height: popupSize.height,
-      width: popupSize.width,
-    },
-  });
+  return ChromeLocalStorage.updatePopupSizeSetting(popupSize);
 };
 
 export const getPopupElementScaleSetting = async (): Promise<number> => {
-  const { popup_element_scale: setting } = (await chrome.storage.local.get(
-    ChromeLocalStorage.POPUP_ELEMENT_SCALE_SETTING_KEY,
-  )) as PopupElementScaleSettingStorageObject;
+  const setting = await ChromeLocalStorage.getPopupElementScaleSetting();
   if (!setting) return 80;
 
   return setting;
@@ -36,9 +23,7 @@ export const getPopupElementScaleSetting = async (): Promise<number> => {
 export const updatePopupElementScaleSetting = (
   scale: number,
 ): Promise<void> => {
-  return chrome.storage.local.set({
-    [ChromeLocalStorage.POPUP_ELEMENT_SCALE_SETTING_KEY]: scale,
-  });
+  return ChromeLocalStorage.updatePopupElementScaleSetting(scale);
 };
 
 export const navigateToOptionsPage = () => {

--- a/src/repository/TabCleanerRepository.ts
+++ b/src/repository/TabCleanerRepository.ts
@@ -1,14 +1,9 @@
 import { TabCleaner, defaultTabCleaner } from "../model/TabCleaner";
 
-import {
-  ChromeLocalStorage,
-  TabCleanerSettingStorageObject,
-} from "./ChromeStorage";
+import { ChromeLocalStorage } from "./ChromeStorage";
 
 export const getTabCleanerSetting = async (): Promise<TabCleaner> => {
-  const { tab_cleaner_setting: setting } = (await chrome.storage.local.get(
-    ChromeLocalStorage.TAB_CLEANER_SETTING_KEY,
-  )) as TabCleanerSettingStorageObject;
+  const setting = await ChromeLocalStorage.getTabCleanerSetting();
   if (!setting) return defaultTabCleaner;
 
   return {
@@ -21,11 +16,5 @@ export const getTabCleanerSetting = async (): Promise<TabCleaner> => {
 export const updateTabCleanerSetting = (
   tabCleaner: TabCleaner,
 ): Promise<void> => {
-  return chrome.storage.local.set({
-    [ChromeLocalStorage.TAB_CLEANER_SETTING_KEY]: {
-      isEnabled: tabCleaner.enabled,
-      duration: tabCleaner.duration,
-      durationUnit: tabCleaner.durationUnit,
-    },
-  });
+  return ChromeLocalStorage.updateTabCleanerSetting(tabCleaner);
 };

--- a/src/repository/TabGroupSettingRepository.ts
+++ b/src/repository/TabGroupSettingRepository.ts
@@ -5,24 +5,17 @@ import {
   defaultTabGroupSetting,
 } from "../model/TabGroupSetting";
 
-import {
-  ChromeLocalStorage,
-  TabGroupSettingStorageObject,
-} from "./ChromeStorage";
+import { ChromeLocalStorage } from "./ChromeStorage";
 
 export const getTabGroupSetting = async (): Promise<TabGroupSetting> => {
-  const { tab_group_setting: tabGroupSetting } =
-    (await chrome.storage.local.get(
-      ChromeLocalStorage.TAB_GROUP_SETTING_KEY,
-    )) as TabGroupSettingStorageObject;
+  const setting = await ChromeLocalStorage.getTabGroupSetting();
+  if (!setting) return defaultTabGroupSetting;
 
-  return tabGroupSetting ?? defaultTabGroupSetting;
+  return setting;
 };
 
 export const updateTabGroupSetting = async (setting: TabGroupSetting) => {
-  await chrome.storage.local.set({
-    [ChromeLocalStorage.TAB_GROUP_SETTING_KEY]: setting,
-  });
+  return ChromeLocalStorage.updateTabGroupSetting(setting);
 };
 
 export const addListenerOnUpdateTabGroupSetting = (

--- a/src/repository/TabsRepository.ts
+++ b/src/repository/TabsRepository.ts
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-floating-promises: 0 */
-
 import { Tab, TabId } from "../model/Tab";
 import { WindowId } from "../model/Window";
 
@@ -245,13 +243,11 @@ export const addListenerOnUpdateTabs = (callback: () => Promise<void>) => {
   const listener = async () => {
     await callback();
   };
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   chrome.tabs.onUpdated.addListener(listener);
 
   return listener;
 };
 
 export const removeListenerOnUpdateTabs = (listener: () => Promise<void>) => {
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   chrome.tabs.onUpdated.removeListener(listener);
 };

--- a/src/repository/ThemeRepository.ts
+++ b/src/repository/ThemeRepository.ts
@@ -1,18 +1,14 @@
-import { ChromeLocalStorage, ThemeStorageObject } from "./ChromeStorage";
+import { ChromeLocalStorage } from "./ChromeStorage";
 
 type Theme = "light" | "dark";
 
 export const getTheme = async (): Promise<Theme> => {
-  const { theme } = (await chrome.storage.local.get(
-    ChromeLocalStorage.THEME_KEY,
-  )) as ThemeStorageObject;
+  const theme = await ChromeLocalStorage.getTheme();
   if (!theme) return "light";
 
-  return theme as Theme;
+  return theme;
 };
 
 export const updateTheme = (theme: Theme): Promise<void> => {
-  return chrome.storage.local.set({
-    [ChromeLocalStorage.THEME_KEY]: theme,
-  });
+  return ChromeLocalStorage.updateTheme(theme);
 };

--- a/src/utility/hash.ts
+++ b/src/utility/hash.ts
@@ -1,0 +1,10 @@
+export const generateHash = async (value: string) => {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(value);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return hashHex;
+};

--- a/src/view/components/ActionMenu.tsx
+++ b/src/view/components/ActionMenu.tsx
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-misused-promises: 0 */
-
 import CancelPresentationIcon from "@mui/icons-material/CancelPresentation";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import CropFreeIcon from "@mui/icons-material/CropFree";

--- a/src/view/components/DragAndDropContext.tsx
+++ b/src/view/components/DragAndDropContext.tsx
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-floating-promises: 0, @typescript-eslint/no-misused-promises: 0 */
-
 import {
   Active,
   CollisionDetection,

--- a/src/view/components/OrganizationPage/TabCleanerForm.tsx
+++ b/src/view/components/OrganizationPage/TabCleanerForm.tsx
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-floating-promises: 0 */
-
 import FormControl from "@mui/material/FormControl";
 import InputLabel from "@mui/material/InputLabel";
 import List from "@mui/material/List";

--- a/src/view/components/OrganizationPage/TabGroupingForm.tsx
+++ b/src/view/components/OrganizationPage/TabGroupingForm.tsx
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-floating-promises: 0, @typescript-eslint/no-misused-promises: 0 */
-
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import FormControl from "@mui/material/FormControl";

--- a/src/view/components/RestorePage/StoredTabGroups.tsx
+++ b/src/view/components/RestorePage/StoredTabGroups.tsx
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-floating-promises: 0 */
-
 import CircleIcon from "@mui/icons-material/Circle";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";

--- a/src/view/components/RestorePage/StoredWindows.tsx
+++ b/src/view/components/RestorePage/StoredWindows.tsx
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-floating-promises: 0 */
-
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";

--- a/src/view/components/TabGroupContainer.tsx
+++ b/src/view/components/TabGroupContainer.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
-
 import CircleIcon from "@mui/icons-material/Circle";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import ExpandLess from "@mui/icons-material/ExpandLess";

--- a/src/view/components/TabItem.tsx
+++ b/src/view/components/TabItem.tsx
@@ -103,7 +103,6 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
     event: React.MouseEvent<HTMLElement>,
   ) => {
     event.stopPropagation();
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     resolveDuplicateTabs(tab);
     setIsDuplicatedChipHovered(false);
   };
@@ -124,11 +123,7 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
               <MoreVertIcon />
             </IconButton>
             <Divider orientation="vertical" variant="middle" flexItem />
-            <IconButton
-              edge="end"
-              // eslint-disable-next-line @typescript-eslint/no-misused-promises
-              onClick={onClickDeleteButton}
-            >
+            <IconButton edge="end" onClick={onClickDeleteButton}>
               <Clear />
             </IconButton>
           </Stack>
@@ -143,7 +138,6 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
         style={{ cursor: "inherit" }}
         color="info"
         selected={tab.highlighted || selected}
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onClick={onTapTabItem}
       >
         {showDragIndicatorIcon && isHovered && (
@@ -189,7 +183,6 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
                   component="span"
                   onMouseEnter={() => setIsDuplicatedChipHovered(true)}
                   onMouseLeave={() => setIsDuplicatedChipHovered(false)}
-                  // eslint-disable-next-line @typescript-eslint/no-misused-promises
                   onClick={onClickResolveDuplicatesChip}
                   clickable
                 />

--- a/src/view/contexts/StoredTabGroupsContext.ts
+++ b/src/view/contexts/StoredTabGroupsContext.ts
@@ -10,7 +10,6 @@ type StoredTabGroupsContextType = {
 export const StoredTabGroupsContext = createContext<StoredTabGroupsContextType>(
   {
     storedTabGroups: [],
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     setStoredTabGroups: () => {},
   },
 );

--- a/src/view/contexts/StoredWindowsContext.ts
+++ b/src/view/contexts/StoredWindowsContext.ts
@@ -9,6 +9,5 @@ type StoredWindowsContextType = {
 
 export const StoredWindowsContext = createContext<StoredWindowsContextType>({
   storedWindows: [],
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   setStoredWindows: () => {},
 });

--- a/src/view/contexts/ThemeContext.ts
+++ b/src/view/contexts/ThemeContext.ts
@@ -9,6 +9,5 @@ type ThemeContextType = {
 
 export const ThemeContext = createContext<ThemeContextType>({
   theme: null,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   setTheme: () => {},
 });

--- a/src/view/contexts/WindowsContext.ts
+++ b/src/view/contexts/WindowsContext.ts
@@ -9,6 +9,5 @@ type WindowsContextType = {
 
 export const WindowsContext = createContext<WindowsContextType>({
   windows: [],
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   setWindows: () => {},
 });

--- a/src/view/features/options/components/Header.tsx
+++ b/src/view/features/options/components/Header.tsx
@@ -20,7 +20,6 @@ const Header = () => {
           TabTabTab
         </Typography>
         <IconButton
-          // eslint-disable-next-line @typescript-eslint/no-misused-promises
           onClick={() => toggleTheme(theme === "light" ? "dark" : "light")}
           color="inherit"
         >

--- a/src/view/features/options/pages/Feedback/index.tsx
+++ b/src/view/features/options/pages/Feedback/index.tsx
@@ -34,7 +34,7 @@ const Feedback = () => {
 
   return (
     <Stack spacing={2}>
-      {feedbacks.map((feedback, index) => {
+      {feedbacks.map((feedback) => {
         return (
           <CardActionArea>
             <Link

--- a/src/view/features/options/pages/Overview/index.tsx
+++ b/src/view/features/options/pages/Overview/index.tsx
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-misused-promises: 0 */
-
 import { useDroppable } from "@dnd-kit/core";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import Box from "@mui/material/Box";

--- a/src/view/features/options/pages/Settings/PopupElementScaleSettingForm.tsx
+++ b/src/view/features/options/pages/Settings/PopupElementScaleSettingForm.tsx
@@ -78,7 +78,7 @@ const PopupFontAndIconScaleSettingForm = () => {
         errorMessage: "",
       });
       setIsOpenSnackBarState(true);
-    } catch (e) {
+    } catch (_) {
       setSubmissionState({
         isLoading: false,
         isError: true,

--- a/src/view/features/options/pages/Settings/PopupElementScaleSettingForm.tsx
+++ b/src/view/features/options/pages/Settings/PopupElementScaleSettingForm.tsx
@@ -40,7 +40,6 @@ const PopupFontAndIconScaleSettingForm = () => {
       const scale = await getPopupElementScaleSetting();
       setSettingState(scale.toString());
     };
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     setSetting();
   }, []);
 
@@ -127,7 +126,6 @@ const PopupFontAndIconScaleSettingForm = () => {
             disabled={submissionState.isLoading}
             sx={{ textTransform: "none" }}
             disableElevation
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onClick={onSave}
           >
             {submissionState.isLoading ? `${t.saving}...` : t.save}

--- a/src/view/features/options/pages/Settings/PopupSizeSettingForm.tsx
+++ b/src/view/features/options/pages/Settings/PopupSizeSettingForm.tsx
@@ -101,7 +101,7 @@ const PopupSizeSettingForm = () => {
         errorMessage: "",
       });
       setIsOpenSnackBarState(true);
-    } catch (e) {
+    } catch (_) {
       setSubmissionState({
         isLoading: false,
         isError: true,

--- a/src/view/features/options/pages/Settings/PopupSizeSettingForm.tsx
+++ b/src/view/features/options/pages/Settings/PopupSizeSettingForm.tsx
@@ -52,7 +52,6 @@ const PopupSizeSettingForm = () => {
         width: setting.width.toString(),
       });
     };
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     setSetting();
   }, []);
 
@@ -163,7 +162,6 @@ const PopupSizeSettingForm = () => {
             disabled={submissionState.isLoading}
             sx={{ textTransform: "none" }}
             disableElevation
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onClick={onSave}
           >
             {submissionState.isLoading ? `${t.saving}...` : t.save}

--- a/src/view/features/popup/components/Header.tsx
+++ b/src/view/features/popup/components/Header.tsx
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-misused-promises: 0 */
-
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import AutoAwesomeMotionIcon from "@mui/icons-material/AutoAwesomeMotion";
 import ClearIcon from "@mui/icons-material/Clear";

--- a/src/view/features/popup/components/Home.tsx
+++ b/src/view/features/popup/components/Home.tsx
@@ -23,7 +23,6 @@ const Home = () => {
     const initState = async () => {
       setPopupSizeState(await getPopupSizeSetting());
     };
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     initState();
   }, []);
 

--- a/src/view/features/popup/components/SearchResult.tsx
+++ b/src/view/features/popup/components/SearchResult.tsx
@@ -69,7 +69,6 @@ const SearchResult = (props: SearchResultProps) => {
           oldIndex === minIndex ? maxIndex : oldIndex - 1,
         );
       } else if (event.key === "Enter") {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         focusTab(tabs[selectedTabIndex]);
       }
     };
@@ -86,7 +85,6 @@ const SearchResult = (props: SearchResultProps) => {
       const tabs = await getRecentActiveTabs();
       setRecentActiveTabs(tabs);
     };
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     initializeState();
   }, []);
 

--- a/src/view/features/popup/components/ThemeProvider.tsx
+++ b/src/view/features/popup/components/ThemeProvider.tsx
@@ -18,7 +18,6 @@ const PopupThemeProvider = (props: ThemeProviderProps) => {
     const initState = async () => {
       setScale(await getPopupElementScaleSetting());
     };
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     initState();
   }, []);
 

--- a/src/view/hooks/useStoredTabGroups.ts
+++ b/src/view/hooks/useStoredTabGroups.ts
@@ -10,7 +10,6 @@ export const useStoredTabGroups = () => {
       const storedTabGroups = await getStoredTabGroups();
       setStoredTabGroups(storedTabGroups);
     };
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     initState();
   }, []);
 

--- a/src/view/hooks/useStoredWindows.ts
+++ b/src/view/hooks/useStoredWindows.ts
@@ -10,7 +10,6 @@ export const useStoredWindows = () => {
       const storedWindows = await getStoredWindows();
       setStoredWindows(storedWindows);
     };
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     initState();
   }, []);
 

--- a/src/view/hooks/useTheme.ts
+++ b/src/view/hooks/useTheme.ts
@@ -11,7 +11,6 @@ export const useTheme = () => {
     const initState = async () => {
       setState(await getTheme());
     };
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     initState();
   }, []);
 

--- a/src/view/hooks/useWindows.ts
+++ b/src/view/hooks/useWindows.ts
@@ -28,7 +28,6 @@ export const useWindows = () => {
       const windows = await getWindows();
       setWindows(windows);
     };
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     initState();
 
     const listenerOnUpdateTabs = addListenerOnUpdateTabs(async () => {

--- a/test/model/GroupColor.test.ts
+++ b/test/model/GroupColor.test.ts
@@ -1,4 +1,3 @@
-/* eslint @typescript-eslint/no-unsafe-argument: 0, @typescript-eslint/no-explicit-any: 0 */
 import { GroupColor } from "../../src/model/GroupColor";
 
 describe("#code", () => {

--- a/test/model/TabContainer.test.ts
+++ b/test/model/TabContainer.test.ts
@@ -1,4 +1,3 @@
-/* eslint @typescript-eslint/no-unsafe-argument: 0, @typescript-eslint/no-explicit-any: 0 */
 import { GroupColor } from "../../src/model/GroupColor";
 import {
   isPinned,

--- a/test/model/Window.test.ts
+++ b/test/model/Window.test.ts
@@ -1,4 +1,3 @@
-/* eslint @typescript-eslint/no-unsafe-argument: 0, @typescript-eslint/no-explicit-any: 0 */
 import {
   findParentContainer,
   findPinned,

--- a/test/model/Window.test.ts
+++ b/test/model/Window.test.ts
@@ -12,7 +12,6 @@ import {
   hasDuplicatedTabs,
   indexOfWindowChild,
   moveTabOrTabGroup,
-  updateLastActivatedAtOfTab,
 } from "../../src/model/Window";
 import { mockPinned, mockTabGroup } from "../factory/TabContainerFactory";
 import { mockTab } from "../factory/TabFactory";
@@ -384,33 +383,6 @@ describe("#indexOfWindowChild", () => {
         expect(indexOfWindowChild(window, 10)).toEqual(0);
       });
     });
-  });
-});
-
-describe("#updateLastActivatedAtOfTab", () => {
-  it("should update lastActivatedAt of tab", () => {
-    const tab1 = mockTab({ id: 1, lastActivatedAt: new Date(2023, 8, 20) });
-    const tab2 = mockTab({ id: 2, lastActivatedAt: new Date(2023, 8, 21) });
-    const window1 = mockWindow({ id: 1, children: [tab1] });
-    const window2 = mockWindow({ id: 2, children: [tab2] });
-    const windows = [window1, window2];
-    const lastActivatedAt = new Date(2023, 8, 25);
-    const expected = [
-      window1,
-      {
-        ...window2,
-        children: [
-          {
-            ...tab2,
-            lastActivatedAt,
-          },
-        ],
-      },
-    ];
-
-    expect(updateLastActivatedAtOfTab(windows, 2, lastActivatedAt)).toEqual(
-      expected,
-    );
   });
 });
 


### PR DESCRIPTION
Implemented saving data in `storage.local` using a key generated from the hash of the tab's title and URL. This ensures the last active time of tabs is maintained even after browser restarts.