### PR TITLE
Fix to Exclude Active Tabs from Other Windows in Auto-Grouping When Set to Current Tab Only

### DIFF
--- a/src/background/AutoTabGrouping.ts
+++ b/src/background/AutoTabGrouping.ts
@@ -20,7 +20,13 @@ const onTabUpdated = async (
   if (!setting.enabledAutoGrouping) return;
 
   if (!tab || tab.pinned) return;
-  if (setting.applyAutoGroupingToCurrentTabOnly && !tab.active) return;
+  const currentWindow = await chrome.windows.getCurrent();
+  if (
+    setting.applyAutoGroupingToCurrentTabOnly &&
+    (!tab.active || tab.windowId !== currentWindow.id)
+  ) {
+    return;
+  }
 
   await organizeTabsByGroupingRule(tab, setting);
 };


### PR DESCRIPTION
As described, this update corrects the behavior to ensure that when auto-grouping is set to target only the current tab, active tabs in other windows are not included.