### PR TITLE
Limit window types to only `normal` to prevent display of `devtools` and `popup` windows

### DIFF
--- a/src/repository/ChromeStorage.ts
+++ b/src/repository/ChromeStorage.ts
@@ -296,7 +296,10 @@ export namespace ChromeStorage {
       ChromeLocalStorage.TAB_LAST_ACCESSES_KEY,
     )) as TabLastAccessesLocalStorageObject;
 
-    const windows = await chrome.windows.getAll({ populate: true });
+    const windows = await chrome.windows.getAll({
+      populate: true,
+      windowTypes: ["normal"],
+    });
     const cleanedUpInLocal = {};
     for (const tab of windows.flatMap((window) => window.tabs)) {
       const key = await tabKeyForLastAccessesInLocal(

--- a/src/repository/TabGroupSettingRepository.ts
+++ b/src/repository/TabGroupSettingRepository.ts
@@ -53,7 +53,10 @@ const onTabGroupSettingChanged = (
 };
 
 export const groupTabsBySetting = async (setting: TabGroupSetting) => {
-  const windows = await chrome.windows.getAll({ populate: true });
+  const windows = await chrome.windows.getAll({
+    populate: true,
+    windowTypes: ["normal"],
+  });
   for (const window of windows) {
     await ungroupAll(window.tabs);
 

--- a/src/repository/WindowsRepository.ts
+++ b/src/repository/WindowsRepository.ts
@@ -25,7 +25,10 @@ import { applyLastActivatedAt, parseTab } from "./TabsRepository";
 
 export const getWindows = async (): Promise<Window[]> => {
   const currentWindow = await chrome.windows.getCurrent();
-  const windows = await chrome.windows.getAll({ populate: true });
+  const windows = await chrome.windows.getAll({
+    populate: true,
+    windowTypes: ["normal"],
+  });
 
   const parsedWindows: Window[] = [];
   for (const window of windows) {


### PR DESCRIPTION
for UX