### PR TITLE
Show group names in search results when searching for tabs, if the tab belongs to a group

### DIFF
--- a/src/model/Window.ts
+++ b/src/model/Window.ts
@@ -106,13 +106,18 @@ export const findPinned = (window: Window): Pinned | undefined => {
 };
 
 export const findTabGroup = (
-  window: Window,
   groupId: number,
-): TabGroup | undefined => {
-  const tabGroup = window.children.find((child) => {
-    return isTabGroup(child) && child.id === groupId;
-  });
-  return tabGroup as TabGroup | undefined;
+  container: Window | Window[],
+): TabGroup | null => {
+  const windows = Array.isArray(container) ? container : [container];
+  for (const window of windows) {
+    for (const child of window.children) {
+      if (isTabGroup(child) && child.id === groupId) {
+        return child;
+      }
+    }
+  }
+  return null;
 };
 
 export const indexOfWindowChild = (

--- a/src/model/Window.ts
+++ b/src/model/Window.ts
@@ -108,7 +108,7 @@ export const findPinned = (window: Window): Pinned | undefined => {
 export const findTabGroup = (
   groupId: number,
   container: Window | Window[],
-): TabGroup | null => {
+): TabGroup | undefined => {
   const windows = Array.isArray(container) ? container : [container];
   for (const window of windows) {
     for (const child of window.children) {
@@ -117,7 +117,7 @@ export const findTabGroup = (
       }
     }
   }
-  return null;
+  return;
 };
 
 export const indexOfWindowChild = (

--- a/src/repository/WindowsRepository.ts
+++ b/src/repository/WindowsRepository.ts
@@ -63,7 +63,7 @@ export const getWindows = async (): Promise<Window[]> => {
         }
       } else if (tab.groupId !== chrome.tabGroups.TAB_GROUP_ID_NONE) {
         const groupId = tab.groupId;
-        const tabGroup = findTabGroup(parsedWindow, groupId);
+        const tabGroup = findTabGroup(groupId, parsedWindow);
         if (tabGroup) {
           parsedWindow.children = parsedWindow.children.map((child) => {
             if (isTabGroup(child) && child.id === groupId) {

--- a/src/view/components/DragAndDropContext.tsx
+++ b/src/view/components/DragAndDropContext.tsx
@@ -472,7 +472,7 @@ const DragAndDropContext = (props: DragAndDropContextProps) => {
 
     const source = findWindowChild(
       windows,
-      activeItem.id === "pinned" ? activeItem.id : Number(activeItem.id),
+      isPinnedId(activeItem.id) ? activeItem.id : Number(activeItem.id),
     );
     if (!source) return null;
 
@@ -501,7 +501,7 @@ const DragAndDropContext = (props: DragAndDropContextProps) => {
           opacity: overItem?.data?.current?.type === "window" ? "0.5" : "1",
         }}
       >
-        <TabItem tab={tab} />
+        <TabItem tab={tab} cursorGrabbing />
       </div>
     );
   }, [activeItem, overItem, windows]);

--- a/src/view/components/SortableTabs.tsx
+++ b/src/view/components/SortableTabs.tsx
@@ -30,7 +30,7 @@ const SortableTabs = (props: SortableTabsProps) => {
           id={tab.id.toString()}
           data={{ type: "tab", parentType: parentType, windowId }}
         >
-          <TabItem tab={tab} />
+          <TabItem tab={tab} cursorGrabbing />
         </SortableItem>
       ))}
     </SortableContext>

--- a/src/view/components/TabItem.tsx
+++ b/src/view/components/TabItem.tsx
@@ -26,6 +26,7 @@ import TabFavicon from "./TabFavicon";
 type TabItemProps = {
   tab: Tab;
   selected?: boolean;
+  cursorGrabbing?: boolean;
   showDragIndicatorIcon?: boolean;
   showActions?: boolean;
   showDuplicatedChip?: boolean;
@@ -36,6 +37,7 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
   const {
     tab,
     selected,
+    cursorGrabbing = false,
     showDragIndicatorIcon = true,
     showActions = true,
     showDuplicatedChip = true,
@@ -161,7 +163,7 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
     >
       <ListItemButton
         sx={{ width: "100%", pt: 0, pb: 0 }}
-        style={{ cursor: "inherit" }}
+        style={{ cursor: cursorGrabbing ? "inherit" : "pointer" }}
         color="info"
         selected={tab.active || selected}
         onClick={onTapTabItem}

--- a/src/view/components/TabItem.tsx
+++ b/src/view/components/TabItem.tsx
@@ -1,3 +1,4 @@
+import CircleIcon from "@mui/icons-material/Circle";
 import Clear from "@mui/icons-material/Clear";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
@@ -11,10 +12,11 @@ import ListItemText from "@mui/material/ListItemText";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import grey from "@mui/material/colors/grey";
+import { useTheme } from "@mui/material/styles";
 import { forwardRef, useContext, useState } from "react";
 import t from "../../i18n/Translations";
 import { Tab, durationSinceLastActivatedAt } from "../../model/Tab";
-import { hasDuplicatedTabs } from "../../model/Window";
+import { findTabGroup, hasDuplicatedTabs } from "../../model/Window";
 import { closeTab, focusTab } from "../../repository/TabsRepository";
 import { WindowsContext } from "../contexts/WindowsContext";
 import { resolveDuplicatedTabs } from "../functions/resolveDuplicatedTabs";
@@ -27,6 +29,7 @@ type TabItemProps = {
   showDragIndicatorIcon?: boolean;
   showActions?: boolean;
   showDuplicatedChip?: boolean;
+  showBelongingGroup?: boolean;
 };
 
 const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
@@ -36,6 +39,7 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
     showDragIndicatorIcon = true,
     showActions = true,
     showDuplicatedChip = true,
+    showBelongingGroup = false,
   } = props;
   const { windows } = useContext(WindowsContext);
   const onTapTabItem = () => focusTab(tab);
@@ -100,6 +104,33 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
     event.stopPropagation();
     resolveDuplicatedTabs(windows, tab);
     setIsDuplicatedChipHovered(false);
+  };
+
+  const BelongingTabGroup = () => {
+    const theme = useTheme();
+    const group = findTabGroup(tab.groupId, windows);
+    if (!group) return;
+
+    return (
+      <>
+        <CircleIcon
+          sx={{
+            color: group.color.code,
+            fontSize: theme.spacing(1),
+          }}
+        />
+        <span
+          style={{
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {group.name}
+        </span>
+        <span>•</span>
+      </>
+    );
   };
 
   return (
@@ -190,7 +221,8 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
             </Typography>
           }
           secondary={
-            <span style={{ display: "flex" }}>
+            <Stack direction="row" alignItems="center" spacing={0.5}>
+              {showBelongingGroup && <BelongingTabGroup />}
               <span
                 style={{
                   whiteSpace: "nowrap",
@@ -200,11 +232,11 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
               >
                 {tab.url.host}
               </span>
-              {elapsedTimeText !== "" && <span>・</span>}
+              {elapsedTimeText !== "" && <span>•</span>}
               {elapsedTimeText !== "" && (
                 <span style={{ whiteSpace: "nowrap" }}>{elapsedTimeText}</span>
               )}
-            </span>
+            </Stack>
           }
         />
       </ListItemButton>

--- a/src/view/components/TabList.tsx
+++ b/src/view/components/TabList.tsx
@@ -70,7 +70,7 @@ const TabList = memo((props: TabListProps) => {
         id={tab.id.toString()}
         data={{ type: "tab", parentType: "window", windowId: window.id }}
       >
-        <TabItem tab={tab} />
+        <TabItem tab={tab} cursorGrabbing />
       </SortableItem>
     );
   };

--- a/src/view/features/popup/components/SearchResult.tsx
+++ b/src/view/features/popup/components/SearchResult.tsx
@@ -131,6 +131,7 @@ const SearchResult = (props: SearchResultProps) => {
               tab={{ ...tab, active: false }}
               selected={selectedTabIndex === i}
               showDragIndicatorIcon={false}
+              showBelongingGroup
             />
           ))}
         </List>

--- a/src/view/features/popup/components/SearchResult.tsx
+++ b/src/view/features/popup/components/SearchResult.tsx
@@ -4,7 +4,6 @@ import List from "@mui/material/List";
 import ListSubheader from "@mui/material/ListSubheader";
 import Typography from "@mui/material/Typography";
 import { useContext, useEffect, useRef, useState } from "react";
-
 import t from "../../../../i18n/Translations";
 import { Tab } from "../../../../model/Tab";
 import { findTabsByTitleOrUrl } from "../../../../model/Window";
@@ -124,12 +123,12 @@ const SearchResult = (props: SearchResultProps) => {
           sx={{ width: "100%", bgcolor: "background.paper", overflowY: "auto" }}
           disablePadding
         >
-          {tabs.map((tab, i) => (
+          {tabs.map((tab, index) => (
             <TabItem
               key={tab.id}
-              ref={i === selectedTabIndex ? selectedItemRef : null}
+              ref={index === selectedTabIndex ? selectedItemRef : null}
               tab={{ ...tab, active: false }}
-              selected={selectedTabIndex === i}
+              selected={selectedTabIndex === index}
               showDragIndicatorIcon={false}
               showBelongingGroup
             />

--- a/test/model/Window.test.ts
+++ b/test/model/Window.test.ts
@@ -42,7 +42,7 @@ describe("#flatTabsInWindows", () => {
         const tabs1 = [mockTab({ id: 1 }), mockTab({ id: 2 })];
         const tabs2 = [mockTab({ id: 3 }), mockTab({ id: 4 })];
         const tabs3 = [mockTab({ id: 5 }), mockTab({ id: 6 })];
-        const pinned = mockPinned({ id: "pinned", children: tabs1 });
+        const pinned = mockPinned({ id: "pinned-1", children: tabs1 });
         const tabGroup = mockTabGroup({ id: 1, children: tabs2 });
         const windows = [
           mockWindow({ id: 1, children: [pinned] }),
@@ -82,7 +82,7 @@ describe("#flatTabsInWindow", () => {
         const tabs1 = [mockTab({ id: 1 }), mockTab({ id: 2 })];
         const tabs2 = [mockTab({ id: 3 }), mockTab({ id: 4 })];
         const tabs3 = [mockTab({ id: 5 }), mockTab({ id: 6 })];
-        const pinned = mockPinned({ id: "pinned", children: tabs1 });
+        const pinned = mockPinned({ id: "pinned-1", children: tabs1 });
         const tabGroup = mockTabGroup({ id: 1, children: tabs2 });
         const window = mockWindow({
           id: 1,
@@ -122,7 +122,7 @@ describe("#findParentContainer", () => {
       it("should return Pinned", () => {
         const tab1 = mockTab({ id: 1 });
         const tab2 = mockTab({ id: 2 });
-        const pinned = mockPinned({ id: "pinned", children: [tab1] });
+        const pinned = mockPinned({ id: "pinned-100", children: [tab1] });
         const window = mockWindow({ id: 100, children: [pinned, tab2] });
 
         expect(findParentContainer(window, 1)).toEqual(pinned);
@@ -270,7 +270,7 @@ describe("#findPinned", () => {
     describe("when pinned is found", () => {
       it("should return pinned", () => {
         const tab = mockTab({ id: 1 });
-        const pinned = mockPinned({ id: "pinned", children: [tab] });
+        const pinned = mockPinned({ id: "pinned-1", children: [tab] });
         const window = mockWindow({ id: 1, children: [pinned] });
 
         expect(findPinned(window)).toEqual(pinned);
@@ -292,7 +292,7 @@ describe("#findTabGroup", () => {
   describe("when windows is empty", () => {
     it("should return undefined", () => {
       const window = mockWindow({ id: 1, children: [] });
-      expect(findTabGroup(window, 1)).toBeUndefined();
+      expect(findTabGroup(1, window)).toBeUndefined();
     });
   });
 
@@ -303,7 +303,7 @@ describe("#findTabGroup", () => {
         const tabGroup = mockTabGroup({ id: 1, children: [tab] });
         const window = mockWindow({ id: 1, children: [tabGroup] });
 
-        expect(findTabGroup(window, 1)).toEqual(tabGroup);
+        expect(findTabGroup(1, window)).toEqual(tabGroup);
       });
     });
 
@@ -313,7 +313,7 @@ describe("#findTabGroup", () => {
         const tabGroup = mockTabGroup({ id: 1, children: [tab] });
         const window = mockWindow({ id: 1, children: [tabGroup] });
 
-        expect(findTabGroup(window, 2)).toBeUndefined();
+        expect(findTabGroup(2, window)).toBeUndefined();
       });
     });
   });
@@ -355,7 +355,7 @@ describe("#indexOfWindowChild", () => {
         const tab4 = mockTab({ id: 4 });
         const tab5 = mockTab({ id: 5 });
         const tab6 = mockTab({ id: 6 });
-        const pinned = mockPinned({ id: "pinned", children: [tab2] });
+        const pinned = mockPinned({ id: "pinned-100", children: [tab2] });
         const tabGroup1 = mockTabGroup({ id: 10, children: [tab3, tab4] });
         const tabGroup2 = mockTabGroup({ id: 11, children: [tab5, tab6] });
         const window = mockWindow({
@@ -474,13 +474,23 @@ describe("#moveTabOrTabGroup", () => {
           const tab3 = mockTab({ id: 3 });
           const tab4 = mockTab({ id: 4 });
           const tab5 = mockTab({ id: 5 });
-          const pinned = mockPinned({ id: "pinned", children: [tab1, tab2] });
+          const pinned = mockPinned({
+            id: "pinned-100",
+            children: [tab1, tab2],
+          });
           const window = mockWindow({
             id: 100,
             children: [pinned, tab3, tab4, tab5],
           });
 
-          const actual = moveTabOrTabGroup([window], 3, 100, 100, "pinned", 1);
+          const actual = moveTabOrTabGroup(
+            [window],
+            3,
+            100,
+            100,
+            "pinned-100",
+            1,
+          );
           const expected = [
             mockWindow({
               id: 100,
@@ -532,7 +542,10 @@ describe("#moveTabOrTabGroup", () => {
           const tab3 = mockTab({ id: 3 });
           const tab4 = mockTab({ id: 4 });
           const tab5 = mockTab({ id: 5 });
-          const pinned = mockPinned({ id: "pinned", children: [tab1, tab2] });
+          const pinned = mockPinned({
+            id: "pinned-100",
+            children: [tab1, tab2],
+          });
           const window = mockWindow({
             id: 100,
             children: [pinned, tab3, tab4, tab5],
@@ -562,13 +575,23 @@ describe("#moveTabOrTabGroup", () => {
           const tab3 = mockTab({ id: 3 });
           const tab4 = mockTab({ id: 4 });
           const tab5 = mockTab({ id: 5 });
-          const pinned = mockPinned({ id: "pinned", children: [tab1, tab2] });
+          const pinned = mockPinned({
+            id: "pinned-100",
+            children: [tab1, tab2],
+          });
           const window = mockWindow({
             id: 100,
             children: [pinned, tab3, tab4, tab5],
           });
 
-          const actual = moveTabOrTabGroup([window], 2, 100, 100, "pinned", 0);
+          const actual = moveTabOrTabGroup(
+            [window],
+            2,
+            100,
+            100,
+            "pinned-100",
+            0,
+          );
           const expected = [
             mockWindow({
               id: 100,
@@ -591,7 +614,10 @@ describe("#moveTabOrTabGroup", () => {
           const tab3 = mockTab({ id: 3 });
           const tab4 = mockTab({ id: 4 });
           const tab5 = mockTab({ id: 5 });
-          const pinned = mockPinned({ id: "pinned", children: [tab1, tab2] });
+          const pinned = mockPinned({
+            id: "pinned-100",
+            children: [tab1, tab2],
+          });
           const tabGroup = mockTabGroup({ id: 10, children: [tab3, tab4] });
           const window = mockWindow({
             id: 100,
@@ -652,14 +678,21 @@ describe("#moveTabOrTabGroup", () => {
           const tab3 = mockTab({ id: 3 });
           const tab4 = mockTab({ id: 4 });
           const tab5 = mockTab({ id: 5 });
-          const pinned = mockPinned({ id: "pinned", children: [tab1] });
+          const pinned = mockPinned({ id: "pinned-100", children: [tab1] });
           const tabGroup = mockTabGroup({ id: 10, children: [tab3, tab4] });
           const window = mockWindow({
             id: 100,
             children: [pinned, tab2, tabGroup, tab5],
           });
 
-          const actual = moveTabOrTabGroup([window], 3, 100, 100, "pinned", 0);
+          const actual = moveTabOrTabGroup(
+            [window],
+            3,
+            100,
+            100,
+            "pinned-100",
+            0,
+          );
           const expected = [
             mockWindow({
               id: 100,
@@ -682,7 +715,7 @@ describe("#moveTabOrTabGroup", () => {
           const tab3 = mockTab({ id: 3 });
           const tab4 = mockTab({ id: 4 });
           const tab5 = mockTab({ id: 5 });
-          const pinned = mockPinned({ id: "pinned", children: [tab1] });
+          const pinned = mockPinned({ id: "pinned-100", children: [tab1] });
           const tabGroup = mockTabGroup({ id: 10, children: [tab3, tab4] });
           const window = mockWindow({
             id: 100,
@@ -743,7 +776,7 @@ describe("#moveTabOrTabGroup", () => {
       const tab3 = mockTab({ id: 3 });
       const tab4 = mockTab({ id: 4 });
       const tab5 = mockTab({ id: 5 });
-      const pinned = mockPinned({ id: "pinned", children: [tab1, tab2] });
+      const pinned = mockPinned({ id: "pinned-100", children: [tab1, tab2] });
       const window = mockWindow({
         id: 100,
         children: [pinned, tab3, tab4, tab5],


### PR DESCRIPTION
like this

<img width="400" alt="Screenshot 2024-03-02 at 13 04 43" src="https://github.com/okaryo/TabTabTab/assets/44517313/eb98d9f2-e317-4325-be0e-4380f66f5f17">
