### PR TITLE
Added Actions to Open New Tabs in Tabs, Groups, and Windows

### DIFF
--- a/dist/_locales/bg/messages.json
+++ b/dist/_locales/bg/messages.json
@@ -143,6 +143,10 @@
     "message": "Добавяне на нов раздел в групата",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_window": {
+    "message": "Добавяне на нов раздел",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Закачи",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/bg/messages.json
+++ b/dist/_locales/bg/messages.json
@@ -135,6 +135,10 @@
     "message": "Дубликат",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_next": {
+    "message": "Добавяне на нов раздел до",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Закачи",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/bg/messages.json
+++ b/dist/_locales/bg/messages.json
@@ -139,6 +139,10 @@
     "message": "Добавяне на нов раздел до",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_group": {
+    "message": "Добавяне на нов раздел в групата",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Закачи",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/de/messages.json
+++ b/dist/_locales/de/messages.json
@@ -139,6 +139,10 @@
     "message": "Neuen Tab daneben hinzufügen",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_group": {
+    "message": "Neuen Tab in Gruppe hinzufügen",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Anpinnen",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/de/messages.json
+++ b/dist/_locales/de/messages.json
@@ -135,6 +135,10 @@
     "message": "Duplikat",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_next": {
+    "message": "Neuen Tab daneben hinzufügen",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Anpinnen",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/de/messages.json
+++ b/dist/_locales/de/messages.json
@@ -143,6 +143,10 @@
     "message": "Neuen Tab in Gruppe hinzufügen",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_window": {
+    "message": "Neuen Tab hinzufügen",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Anpinnen",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/en/messages.json
+++ b/dist/_locales/en/messages.json
@@ -135,6 +135,10 @@
     "message": "Duplicate",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_next": {
+    "message": "Add New Tab Next",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Pin",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/en/messages.json
+++ b/dist/_locales/en/messages.json
@@ -136,7 +136,11 @@
     "description": "Displayed within the action menu for tabs."
   },
   "add_new_tab_next": {
-    "message": "Add New Tab Next",
+    "message": "New Tab Next",
+    "description": "Displayed within the action menu for tabs."
+  },
+  "add_new_tab_in_group": {
+    "message": "New Tab in Group",
     "description": "Displayed within the action menu for tabs."
   },
   "pin": {

--- a/dist/_locales/en/messages.json
+++ b/dist/_locales/en/messages.json
@@ -143,6 +143,10 @@
     "message": "New Tab in Group",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_window": {
+    "message": "New Tab",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Pin",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/en_GB/messages.json
+++ b/dist/_locales/en_GB/messages.json
@@ -135,6 +135,10 @@
     "message": "Duplicate",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_next": {
+    "message": "Add New Tab Next",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Pin",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/en_GB/messages.json
+++ b/dist/_locales/en_GB/messages.json
@@ -136,7 +136,11 @@
     "description": "Displayed within the action menu for tabs."
   },
   "add_new_tab_next": {
-    "message": "Add New Tab Next",
+    "message": "New Tab Next",
+    "description": "Displayed within the action menu for tabs."
+  },
+  "add_new_tab_in_group": {
+    "message": "New Tab in Group",
     "description": "Displayed within the action menu for tabs."
   },
   "pin": {

--- a/dist/_locales/en_GB/messages.json
+++ b/dist/_locales/en_GB/messages.json
@@ -143,6 +143,10 @@
     "message": "New Tab in Group",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_window": {
+    "message": "New Tab",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Pin",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/en_US/messages.json
+++ b/dist/_locales/en_US/messages.json
@@ -135,6 +135,10 @@
     "message": "Duplicate",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_next": {
+    "message": "Add New Tab Next",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Pin",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/en_US/messages.json
+++ b/dist/_locales/en_US/messages.json
@@ -136,7 +136,11 @@
     "description": "Displayed within the action menu for tabs."
   },
   "add_new_tab_next": {
-    "message": "Add New Tab Next",
+    "message": "New Tab Next",
+    "description": "Displayed within the action menu for tabs."
+  },
+  "add_new_tab_in_group": {
+    "message": "New Tab in Group",
     "description": "Displayed within the action menu for tabs."
   },
   "pin": {

--- a/dist/_locales/en_US/messages.json
+++ b/dist/_locales/en_US/messages.json
@@ -143,6 +143,10 @@
     "message": "New Tab in Group",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_window": {
+    "message": "New Tab",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Pin",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/fr/messages.json
+++ b/dist/_locales/fr/messages.json
@@ -139,6 +139,10 @@
     "message": "Ajouter un nouvel onglet à côté",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_group": {
+    "message": "Ajouter un nouvel onglet dans le groupe",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Epingler",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/fr/messages.json
+++ b/dist/_locales/fr/messages.json
@@ -135,6 +135,10 @@
     "message": "Dupliquer",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_next": {
+    "message": "Ajouter un nouvel onglet à côté",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Epingler",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/fr/messages.json
+++ b/dist/_locales/fr/messages.json
@@ -143,6 +143,10 @@
     "message": "Ajouter un nouvel onglet dans le groupe",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_window": {
+    "message": "Ajouter un nouvel onglet",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Epingler",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/ja/messages.json
+++ b/dist/_locales/ja/messages.json
@@ -135,6 +135,10 @@
     "message": "複製",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_next": {
+    "message": "隣に新しいタブを追加",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "固定",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/ja/messages.json
+++ b/dist/_locales/ja/messages.json
@@ -143,6 +143,10 @@
     "message": "グループ内に新しいタブを追加",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_window": {
+    "message": "新しいタブを追加",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "固定",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/ja/messages.json
+++ b/dist/_locales/ja/messages.json
@@ -139,6 +139,10 @@
     "message": "隣に新しいタブを追加",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_group": {
+    "message": "グループ内に新しいタブを追加",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "固定",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/ko/messages.json
+++ b/dist/_locales/ko/messages.json
@@ -135,6 +135,10 @@
     "message": "복제",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_next": {
+    "message": "옆에 새 탭 추가",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "핀 고정",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/ko/messages.json
+++ b/dist/_locales/ko/messages.json
@@ -139,6 +139,10 @@
     "message": "옆에 새 탭 추가",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_group": {
+    "message": "그룹 내 새 탭 추가",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "핀 고정",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/ko/messages.json
+++ b/dist/_locales/ko/messages.json
@@ -143,6 +143,10 @@
     "message": "그룹 내 새 탭 추가",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_window": {
+    "message": "새 탭 추가",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "핀 고정",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/pl/messages.json
+++ b/dist/_locales/pl/messages.json
@@ -143,6 +143,10 @@
     "message": "Dodaj nową kartę do grupy",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_window": {
+    "message": "Dodaj nową kartę",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Przypnij",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/pl/messages.json
+++ b/dist/_locales/pl/messages.json
@@ -139,6 +139,10 @@
     "message": "Dodaj nową kartę obok",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_in_group": {
+    "message": "Dodaj nową kartę do grupy",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Przypnij",
     "description": "Displayed within the action menu for tabs."

--- a/dist/_locales/pl/messages.json
+++ b/dist/_locales/pl/messages.json
@@ -135,6 +135,10 @@
     "message": "Duplikat",
     "description": "Displayed within the action menu for tabs."
   },
+  "add_new_tab_next": {
+    "message": "Dodaj nową kartę obok",
+    "description": "Displayed within the action menu for tabs."
+  },
   "pin": {
     "message": "Przypnij",
     "description": "Displayed within the action menu for tabs."

--- a/src/data/repository/TabsRepository.ts
+++ b/src/data/repository/TabsRepository.ts
@@ -87,6 +87,15 @@ export const createNewTabNext = async (tabId: number) => {
   });
 };
 
+export const createNewTabInGroup = async (groupId: number) => {
+  const group = await chrome.tabGroups.get(groupId);
+  const newTab = await chrome.tabs.create({
+    windowId: group.windowId,
+    active: false,
+  });
+  return chrome.tabs.group({ tabIds: [newTab.id], groupId });
+};
+
 export const pinTab = async (tabId: number) => {
   await chrome.tabs.update(tabId, { pinned: true });
 };

--- a/src/data/repository/TabsRepository.ts
+++ b/src/data/repository/TabsRepository.ts
@@ -17,10 +17,6 @@ export const focusTab = async (tab: Tab) => {
   }
 };
 
-export const focusTabBy = (tabId: number) => {
-  return chrome.tabs.update(tabId, { active: true });
-};
-
 export const closeTab = async (tabId: number) => {
   await chrome.tabs.remove(tabId);
 };
@@ -72,15 +68,14 @@ export const cleanupTabLastActivatedAt = async (tabId: number) => {
   await ChromeLocalStorage.cleanupTabLastAccesses(keepKeys);
 };
 
-export const getCurrentActiveTabId = async () => {
-  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-  if (tabs.length === 0) return null;
-
-  return tabs[0].id;
-};
-
-export const duplicateTab = (tabId: number) => {
-  return chrome.tabs.duplicate(tabId);
+export const duplicateTab = async (tabId: number) => {
+  const tab = await chrome.tabs.get(tabId);
+  return chrome.tabs.create({
+    index: tab.index + 1,
+    url: tab.url,
+    windowId: tab.windowId,
+    active: false,
+  });
 };
 
 export const pinTab = async (tabId: number) => {

--- a/src/data/repository/TabsRepository.ts
+++ b/src/data/repository/TabsRepository.ts
@@ -96,6 +96,10 @@ export const createNewTabInGroup = async (groupId: number) => {
   return chrome.tabs.group({ tabIds: [newTab.id], groupId });
 };
 
+export const createNewTabInWindow = async (windowId: number) => {
+  return chrome.tabs.create({ windowId, active: false });
+};
+
 export const pinTab = async (tabId: number) => {
   await chrome.tabs.update(tabId, { pinned: true });
 };

--- a/src/data/repository/TabsRepository.ts
+++ b/src/data/repository/TabsRepository.ts
@@ -78,6 +78,15 @@ export const duplicateTab = async (tabId: number) => {
   });
 };
 
+export const createNewTabNext = async (tabId: number) => {
+  const tab = await chrome.tabs.get(tabId);
+  return chrome.tabs.create({
+    index: tab.index + 1,
+    windowId: tab.windowId,
+    active: false,
+  });
+};
+
 export const pinTab = async (tabId: number) => {
   await chrome.tabs.update(tabId, { pinned: true });
 };

--- a/src/i18n/Translations.ts
+++ b/src/i18n/Translations.ts
@@ -120,6 +120,9 @@ class Translations {
   get addNewTabInGroup() {
     return chrome.i18n.getMessage("add_new_tab_in_group");
   }
+  get addNewTabInWindow() {
+    return chrome.i18n.getMessage("add_new_tab_in_window");
+  }
   get pin() {
     return chrome.i18n.getMessage("pin");
   }

--- a/src/i18n/Translations.ts
+++ b/src/i18n/Translations.ts
@@ -114,6 +114,9 @@ class Translations {
   get duplicateTab() {
     return chrome.i18n.getMessage("duplicate_tab");
   }
+  get addNewTabNext() {
+    return chrome.i18n.getMessage("add_new_tab_next");
+  }
   get pin() {
     return chrome.i18n.getMessage("pin");
   }

--- a/src/i18n/Translations.ts
+++ b/src/i18n/Translations.ts
@@ -117,6 +117,9 @@ class Translations {
   get addNewTabNext() {
     return chrome.i18n.getMessage("add_new_tab_next");
   }
+  get addNewTabInGroup() {
+    return chrome.i18n.getMessage("add_new_tab_in_group");
+  }
   get pin() {
     return chrome.i18n.getMessage("pin");
   }

--- a/src/view/components/ActionMenu.tsx
+++ b/src/view/components/ActionMenu.tsx
@@ -29,6 +29,7 @@ import {
 import {
   addTabToNewGroup,
   closeTabs,
+  createNewTabInGroup,
   createNewTabNext,
   duplicateTab,
   pinTab,
@@ -206,6 +207,12 @@ export const TabGroupActionMenu = (props: TabGroupActionMenuProps) => {
   const { tabGroup, isOpenMenu, anchorElement, onCloseMenu } = props;
 
   const items: ActionMenuItemAttrs[] = [
+    {
+      type: "MenuItem",
+      label: t.addNewTabInGroup,
+      icon: <ControlPointIcon fontSize="small" />,
+      action: () => createNewTabInGroup(tabGroup.id),
+    },
     {
       type: "MenuItem",
       label: t.saveTabGroup,

--- a/src/view/components/ActionMenu.tsx
+++ b/src/view/components/ActionMenu.tsx
@@ -29,8 +29,6 @@ import {
   addTabToNewGroup,
   closeTabs,
   duplicateTab,
-  focusTabBy,
-  getCurrentActiveTabId,
   pinTab,
   removeFromGroup,
   screenshotVisibleArea,
@@ -107,11 +105,7 @@ export const TabItemActionMenu = (props: TabItemActionMenuProps) => {
       type: "MenuItem",
       label: t.duplicateTab,
       icon: <ControlPointDuplicateIcon fontSize="small" />,
-      action: async () => {
-        const activeTabId = await getCurrentActiveTabId();
-        await duplicateTab(tab.id);
-        await focusTabBy(activeTabId);
-      },
+      action: () => duplicateTab(tab.id),
     },
     tab.pinned && {
       type: "MenuItem",

--- a/src/view/components/ActionMenu.tsx
+++ b/src/view/components/ActionMenu.tsx
@@ -30,6 +30,7 @@ import {
   addTabToNewGroup,
   closeTabs,
   createNewTabInGroup,
+  createNewTabInWindow,
   createNewTabNext,
   duplicateTab,
   pinTab,
@@ -254,6 +255,12 @@ export const WindowActionMenu = (props: WindowActionMenuProps) => {
   const isLastWindow = currentIndex === windows.length - 1;
 
   const items: ActionMenuItemAttrs[] = [
+    {
+      type: "MenuItem",
+      label: t.addNewTabInWindow,
+      icon: <ControlPointIcon fontSize="small" />,
+      action: () => createNewTabInWindow(window.id),
+    },
     {
       type: "MenuItem",
       label: t.saveWindow,

--- a/src/view/components/ActionMenu.tsx
+++ b/src/view/components/ActionMenu.tsx
@@ -1,5 +1,6 @@
 import CancelPresentationIcon from "@mui/icons-material/CancelPresentation";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import ControlPointIcon from "@mui/icons-material/ControlPoint";
 import ControlPointDuplicateIcon from "@mui/icons-material/ControlPointDuplicate";
 import CropFreeIcon from "@mui/icons-material/CropFree";
 import HighlightOffIcon from "@mui/icons-material/HighlightOff";
@@ -28,6 +29,7 @@ import {
 import {
   addTabToNewGroup,
   closeTabs,
+  createNewTabNext,
   duplicateTab,
   pinTab,
   removeFromGroup,
@@ -97,6 +99,27 @@ export const TabItemActionMenu = (props: TabItemActionMenuProps) => {
   const items: ActionMenuItemAttrs[] = [
     {
       type: "MenuItem",
+      label: t.addNewTabNext,
+      icon: <ControlPointIcon fontSize="small" />,
+      action: () => createNewTabNext(tab.id),
+    },
+    tab.groupId && {
+      type: "MenuItem",
+      label: t.removeFromGroup,
+      icon: <CropFreeIcon fontSize="small" />,
+      action: () => removeFromGroup(tab.id),
+    },
+    !tab.groupId && {
+      type: "MenuItem",
+      label: t.addToNewGroup,
+      icon: <LibraryAddIcon fontSize="small" />,
+      action: () => addTabToNewGroup(tab.id, tab.windowId),
+    },
+    {
+      type: "Divider",
+    },
+    {
+      type: "MenuItem",
       label: t.copyUrl,
       icon: <ContentCopyIcon fontSize="small" />,
       action: () => navigator.clipboard.writeText(tab.url.href),
@@ -118,18 +141,6 @@ export const TabItemActionMenu = (props: TabItemActionMenuProps) => {
       label: t.pin,
       icon: <PushPinIcon fontSize="small" />,
       action: () => pinTab(tab.id),
-    },
-    tab.groupId && {
-      type: "MenuItem",
-      label: t.removeFromGroup,
-      icon: <CropFreeIcon fontSize="small" />,
-      action: () => removeFromGroup(tab.id),
-    },
-    !tab.groupId && {
-      type: "MenuItem",
-      label: t.addToNewGroup,
-      icon: <LibraryAddIcon fontSize="small" />,
-      action: () => addTabToNewGroup(tab.id, tab.windowId),
     },
     tab.active && {
       type: "Divider",

--- a/src/view/components/TabItem.tsx
+++ b/src/view/components/TabItem.tsx
@@ -164,7 +164,7 @@ const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
       disablePadding
     >
       <ListItemButton
-        sx={{ width: "100%", pt: 0, pb: 0 }}
+        sx={{ width: "100%", py: 0 }}
         style={{ cursor: cursorGrabbing ? "inherit" : "pointer" }}
         selected={tab.active || selected}
         onClick={onTapTabItem}


### PR DESCRIPTION
## Details
Introduced the ability to open new tabs from the following actions:

* Adding a new tab within a window (from window actions)
* Adding a new tab within a group (from group actions)
* Adding a new tab next to the current one (from tab actions)

## UI
### Window Action
<img width="537" alt="Screenshot 2024-03-29 at 10 52 43" src="https://github.com/okaryo/TabTabTab/assets/44517313/03d74638-b2f8-461e-877b-1261b3ae62a3">

### Group Action
<img width="219" alt="Screenshot 2024-03-29 at 10 52 58" src="https://github.com/okaryo/TabTabTab/assets/44517313/eb1bf354-0635-4d5d-9baa-8c7c8c0d5ac1">

### Tab Action
<img width="564" alt="Screenshot 2024-03-29 at 10 52 49" src="https://github.com/okaryo/TabTabTab/assets/44517313/e6716cff-a49f-4a59-8be2-3dfb040c1dfe">

## Notes
If the auto-grouping feature is enabled, opening a new tab within a group will not move it outside of that group.