### PR TITLE
Fix site fetch error and enable manual title input on failure on add tab to saved window/group

### DIFF
--- a/dist/_locales/bg/messages.json
+++ b/dist/_locales/bg/messages.json
@@ -59,6 +59,10 @@
     "message": "Заглавие (автоматично попълнено от URL)",
     "description": "Text used to display the action for save a new tab to stored window/group"
   },
+  "new_tab_form_site_fetch_error": {
+    "message": "Неуспешно извличане. Моля, въведете ръчно.",
+    "description": "Displayed when site title and favicon cannot be fetched automatically."
+  },
   "pinned": {
     "message": "Закачени",
     "description": "Used as a heading for grouping and displaying pinned tabs together."

--- a/dist/_locales/de/messages.json
+++ b/dist/_locales/de/messages.json
@@ -59,6 +59,10 @@
     "message": "Titel (automatisch aus URL ausgefüllt)",
     "description": "Text used to display the action for save a new tab to stored window/group"
   },
+  "new_tab_form_site_fetch_error": {
+    "message": "Abrufen fehlgeschlagen. Bitte manuell eingeben.",
+    "description": "Displayed when site title and favicon cannot be fetched automatically."
+  },
   "pinned": {
     "message": "Angepinnt",
     "description": "Used as a heading for grouping and displaying pinned tabs together."

--- a/dist/_locales/en/messages.json
+++ b/dist/_locales/en/messages.json
@@ -59,6 +59,10 @@
     "message": "Title (auto-filled from URL)",
     "description": "Text used to display the action for save a new tab to stored window/group"
   },
+  "new_tab_form_site_fetch_error": {
+    "message": "Failed to fetch. Please enter manually.",
+    "description": "Displayed when site title and favicon cannot be fetched automatically."
+  },
   "pinned": {
     "message": "Pinned",
     "description": "Used as a heading for grouping and displaying pinned tabs together."

--- a/dist/_locales/en_GB/messages.json
+++ b/dist/_locales/en_GB/messages.json
@@ -59,6 +59,10 @@
     "message": "Title (auto-filled from URL)",
     "description": "Text used to display the action for save a new tab to stored window/group"
   },
+  "new_tab_form_site_fetch_error": {
+    "message": "Failed to fetch. Please enter manually.",
+    "description": "Displayed when site title and favicon cannot be fetched automatically."
+  },
   "pinned": {
     "message": "Pinned",
     "description": "Used as a heading for grouping and displaying pinned tabs together."

--- a/dist/_locales/en_US/messages.json
+++ b/dist/_locales/en_US/messages.json
@@ -59,6 +59,10 @@
     "message": "Title (auto-filled from URL)",
     "description": "Text used to display the action for save a new tab to stored window/group"
   },
+  "new_tab_form_site_fetch_error": {
+    "message": "Failed to fetch. Please enter manually.",
+    "description": "Displayed when site title and favicon cannot be fetched automatically."
+  },
   "pinned": {
     "message": "Pinned",
     "description": "Used as a heading for grouping and displaying pinned tabs together."

--- a/dist/_locales/fr/messages.json
+++ b/dist/_locales/fr/messages.json
@@ -59,6 +59,10 @@
     "message": "Titre (rempli automatiquement à partir de l'URL)",
     "description": "Text used to display the action for save a new tab to stored window/group"
   },
+  "new_tab_form_site_fetch_error": {
+    "message": "Échec de la récupération. Veuillez saisir manuellement.",
+    "description": "Displayed when site title and favicon cannot be fetched automatically."
+  },
   "pinned": {
     "message": "Epinglé",
     "description": "Used as a heading for grouping and displaying pinned tabs together."

--- a/dist/_locales/ja/messages.json
+++ b/dist/_locales/ja/messages.json
@@ -59,6 +59,10 @@
     "message": "タイトル (URLから自動入力)",
     "description": "Text used to display the action for save a new tab to stored window/group"
   },
+  "new_tab_form_site_fetch_error": {
+    "message": "取得に失敗しました。手動で入力してください。",
+    "description": "Displayed when site title and favicon cannot be fetched automatically."
+  },
   "pinned": {
     "message": "固定タブ",
     "description": "Used as a heading for grouping and displaying pinned tabs together."

--- a/dist/_locales/ko/messages.json
+++ b/dist/_locales/ko/messages.json
@@ -59,6 +59,10 @@
     "message": "제목 (URL에서 자동 입력됨)",
     "description": "Text used to display the action for save a new tab to stored window/group"
   },
+  "new_tab_form_site_fetch_error": {
+    "message": "가져오기에 실패했습니다. 수동으로 입력해 주세요.",
+    "description": "Displayed when site title and favicon cannot be fetched automatically."
+  },
   "pinned": {
     "message": "고정됨",
     "description": "Used as a heading for grouping and displaying pinned tabs together."

--- a/dist/_locales/pl/messages.json
+++ b/dist/_locales/pl/messages.json
@@ -59,6 +59,10 @@
     "message": "Tytuł (automatycznie wypełniony z URL)",
     "description": "Text used to display the action for save a new tab to stored window/group"
   },
+  "new_tab_form_site_fetch_error": {
+    "message": "Nie udało się pobrać. Wprowadź ręcznie.",
+    "description": "Displayed when site title and favicon cannot be fetched automatically."
+  },
   "pinned": {
     "message": "Przypięty",
     "description": "Used as a heading for grouping and displaying pinned tabs together."

--- a/src/data/repository/TabGroupRepository.ts
+++ b/src/data/repository/TabGroupRepository.ts
@@ -100,7 +100,7 @@ export const saveTabGroup = async (tabGroup: TabGroup): Promise<void> => {
 
 export const addTabToSavedGroup = async (
   groupId: string,
-  tab: { title: string; url: string; favIconUrl: string },
+  tab: { title: string; url: string; favIconUrl: string | null },
 ): Promise<void> => {
   const storedTabGroups = await ChromeLocalStorage.getStoredTabGroups();
   await ChromeLocalStorage.updateStoredTabGroups(

--- a/src/i18n/Translations.ts
+++ b/src/i18n/Translations.ts
@@ -41,6 +41,9 @@ class Translations {
   get newTabTitleFormPlaceholderToStored() {
     return chrome.i18n.getMessage("new_tab_title_form_placeholder_to_stored");
   }
+  get newTabFormSiteFetchError() {
+    return chrome.i18n.getMessage("new_tab_form_site_fetch_error");
+  }
 
   // Grouped Tabs
   get pinned() {

--- a/src/presentation/views/shared/components/SaveAndRestorePage/AddTabFrom.tsx
+++ b/src/presentation/views/shared/components/SaveAndRestorePage/AddTabFrom.tsx
@@ -40,7 +40,7 @@ const AddTabForm = forwardRef<HTMLDivElement, AddTabFormProps>((props, ref) => {
     setUrl(event.target.value);
   };
   const fetchSiteTitleAndFavicon = useCallback(async (url: string) => {
-    const proxyUrl = `https://corsproxy.io/?${encodeURIComponent(url)}`;
+    const proxyUrl = `https://corsproxy.io/?url=${encodeURIComponent(url)}`;
     const response = await fetch(proxyUrl);
     if (!response.ok) {
       setLoading(false);

--- a/src/presentation/views/shared/components/SaveAndRestorePage/AddTabFrom.tsx
+++ b/src/presentation/views/shared/components/SaveAndRestorePage/AddTabFrom.tsx
@@ -11,7 +11,7 @@ type AddTabFormProps = {
   onComplete: (data: {
     url: string;
     title: string;
-    favIconUrl: string;
+    favIconUrl: string | null;
   }) => void;
   onCancel: () => void;
 };
@@ -25,16 +25,17 @@ const AddTabForm = forwardRef<HTMLDivElement, AddTabFormProps>((props, ref) => {
   const [title, setTitle] = useState("");
   const [favIconUrl, setFavIconUrl] = useState(null);
   const [isTitleEditable, setIsTitleEditable] = useState(false);
+  const [fetchSiteError, setFetchSiteError] = useState(false);
   const canAdd =
     !loading &&
     title !== "" &&
     url &&
-    favIconUrl &&
     URL.canParse(urlWithScheme(url)) &&
-    URL.canParse(urlWithScheme(favIconUrl));
+    (!favIconUrl || (favIconUrl && URL.canParse(urlWithScheme(favIconUrl))));
 
   const onChangeTitle = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);
+    setFetchSiteError(null);
   };
   const onChangeUrl = async (event: React.ChangeEvent<HTMLInputElement>) => {
     setUrl(event.target.value);
@@ -42,10 +43,7 @@ const AddTabForm = forwardRef<HTMLDivElement, AddTabFormProps>((props, ref) => {
   const fetchSiteTitleAndFavicon = useCallback(async (url: string) => {
     const proxyUrl = `https://corsproxy.io/?url=${encodeURIComponent(url)}`;
     const response = await fetch(proxyUrl);
-    if (!response.ok) {
-      setLoading(false);
-      return;
-    }
+    if (!response.ok) throw new Error(response.statusText);
 
     const html = await response.text();
     const domParser = new DOMParser();
@@ -64,15 +62,12 @@ const AddTabForm = forwardRef<HTMLDivElement, AddTabFormProps>((props, ref) => {
     } else {
       setFavIconUrl(null);
     }
-
-    setIsTitleEditable(true);
-    setLoading(false);
   }, []);
   const onClickAddButton = () => {
     onComplete({
       title,
       url: urlWithScheme(url),
-      favIconUrl: urlWithScheme(favIconUrl),
+      favIconUrl: favIconUrl !== null ? urlWithScheme(favIconUrl) : null,
     });
   };
 
@@ -81,12 +76,19 @@ const AddTabForm = forwardRef<HTMLDivElement, AddTabFormProps>((props, ref) => {
     if (!URL.canParse(normalizedUrl)) return;
 
     setLoading(true);
-    try {
-      fetchSiteTitleAndFavicon(normalizedUrl);
-    } catch (error) {
-      console.error("Failed to fetch metadata:", error);
-      setLoading(false);
-    }
+    fetchSiteTitleAndFavicon(normalizedUrl)
+      .then(() => {
+        setFetchSiteError(null);
+      })
+      .catch((error) => {
+        console.error("Failed to fetch metadata:", error);
+        setFavIconUrl(null);
+        setFetchSiteError(true);
+      })
+      .finally(() => {
+        setLoading(false);
+        setIsTitleEditable(true);
+      });
   }, [debouncedUrl, fetchSiteTitleAndFavicon]);
 
   return (
@@ -99,9 +101,12 @@ const AddTabForm = forwardRef<HTMLDivElement, AddTabFormProps>((props, ref) => {
     >
       <Stack sx={{ flexGrow: 1 }} spacing={0.5}>
         <TextField
-          placeholder={t.newTabTitleFormPlaceholderToStored}
           variant="outlined"
           size="small"
+          value={title}
+          placeholder={t.newTabTitleFormPlaceholderToStored}
+          error={fetchSiteError}
+          helperText={fetchSiteError ? t.newTabFormSiteFetchError : null}
           disabled={!isTitleEditable}
           slotProps={{
             input: {
@@ -116,7 +121,6 @@ const AddTabForm = forwardRef<HTMLDivElement, AddTabFormProps>((props, ref) => {
               ),
             },
           }}
-          value={title}
           onChange={onChangeTitle}
         />
         <TextField


### PR DESCRIPTION
## Detail
* Fixed an issue where fetching the title and favicon failed when adding tabs to SavedWindow/Group.
* Enabled manual title input when an error occurs during the fetch process.
* Updated the parameter passed to `corsproxy.io` to match the new format (`?url=` instead of `/?`).

## Link
* https://github.com/okaryo/TabTabTab/discussions/361#discussioncomment-11577402