### PR TITLE
Setup toolbar icon behavior, so that opening dashboard works

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -7,7 +7,6 @@
   "version": "2.38.2",
   "action": {
     "default_title": "TabTabTab",
-    "default_popup": "popup.html",
     "default_icon": {
       "16": "icon_16.png",
       "32": "icon_32.png",

--- a/src/background/ToolBarAction.ts
+++ b/src/background/ToolBarAction.ts
@@ -6,6 +6,7 @@ import {
   getTabGroupSetting,
   groupTabsBySetting,
 } from "../data/repository/TabGroupSettingRepository";
+import { setToolbarIconBehavior } from "../data/repository/ToolbarRepository";
 import { getWindows, saveWindow } from "../data/repository/WindowsRepository";
 import t from "../i18n/Translations";
 
@@ -13,7 +14,7 @@ const saveCurrentWindowId = "saveCurrentWindow";
 const groupTabsNowId = "groupTabsNow";
 const openDashboardId = "openDashboard";
 
-export const addToolBarActions = () => {
+export const addToolBarActions = async () => {
   chrome.contextMenus.create({
     id: saveCurrentWindowId,
     title: t.saveCurrentWindow,
@@ -29,6 +30,9 @@ export const addToolBarActions = () => {
     title: t.openDashboard,
     contexts: ["action"],
   });
+
+  const toolbarSetting = await getToolbarSetting();
+  setToolbarIconBehavior(toolbarSetting.iconClickOpenView);
 
   chrome.action.onClicked.addListener(async () => {
     const toolbarSetting = await getToolbarSetting();

--- a/src/data/repository/ToolbarRepository.ts
+++ b/src/data/repository/ToolbarRepository.ts
@@ -7,7 +7,13 @@ export const setToolbarIconClickOpenView = async (
   const setting = await ChromeLocalStorage.getToolbarSetting();
   const newSetting = { ...setting, iconClickOpenView: view };
   await ChromeLocalStorage.updateToolbarSetting(newSetting);
+  setToolbarIconBehavior(view);
+  return newSetting;
+};
 
+export const setToolbarIconBehavior = async (
+  view: ToolbarSetting["iconClickOpenView"],
+) => {
   switch (view) {
     case "popup":
       await setToolbarIconBehaviorToOpenPopup();
@@ -21,8 +27,6 @@ export const setToolbarIconClickOpenView = async (
     default:
       throw new Error(`Invalid view: ${view}`);
   }
-
-  return newSetting;
 };
 
 export const setToolbarIconBehaviorToOpenPopup = async () => {


### PR DESCRIPTION
This fixes bug #504: Settings / Toolbar / "Select which view to open when the toolbar icon is clicked" doesn't persist properly.

The problem was that `manifest.json` setup:

```
"default_popup": "popup.html",
```

and https://developer.chrome.com/docs/extensions/reference/api/action#popup says:

> Note: The action.onClicked event won't be sent if the extension action has specified a popup to show on click of the current tab.

When the option was changed from the `ToolbarSettingForm.tsx` it works, since `setToolbarIconClickOpenView()` is called that sets up the popup value based on whether `view: ToolbarSetting["iconClickOpenView"]` was  `popup`, `sidePanel` or `dashboard`. 

I refactored the part of `setToolbarIconClickOpenView()` that setup the popup (or not), and now that is called during startup also.

One could omit the change to `manifest.json`, but I removed it, since it is misleading, as that value has no effect any longer.